### PR TITLE
Fix: Link variables.css to enable theme switching

### DIFF
--- a/auctions/templates/auctions/layout.html
+++ b/auctions/templates/auctions/layout.html
@@ -20,6 +20,7 @@
 		<link rel="dns-prefetch" href="//fonts.googleapis.com" />
 
 		<!-- Critical CSS - Load immediately -->
+		<link href="{% static 'css/variables.css' %}" rel="stylesheet" />
 		<link href="{% static 'css/layout.css' %}" rel="stylesheet" />
 		<link href="{% static 'css/auctions/styles.css' %}" rel="stylesheet" />
 


### PR DESCRIPTION
The dark/light mode theme toggle was not working because the `variables.css` file, which contains the color definitions for both themes, was not being loaded in the main `layout.html` template.

This commit adds the necessary `<link>` tag to `layout.html`, ensuring that the CSS variables are available and allowing the theme to change correctly when toggled by the existing JavaScript.