### PR TITLE
docs(docs): add full project audit and rewrite docker guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,11 +271,25 @@ Actualmente, la aplicación no expone APIs públicas, pero utiliza el enrutamien
 
 ## 🧪 Pruebas
 
-Ejecuta la suite de pruebas para asegurarte de que todo funciona correctamente:
+Ejecuta la suite de pruebas (pytest) para asegurarte de que todo funciona correctamente:
 
 ```bash
-python manage.py test
+# Toda la suite con cobertura
+pytest
+
+# Solo unit + integration (sin E2E)
+pytest tests/unit/ tests/integration/
 ```
+
+---
+
+## 📚 Documentación
+
+- [docs/](docs/README.md) — Índice de la documentación del proyecto
+- [docs/Docker.md](docs/Docker.md) — Stack de contenedores (dev, producción, Heroku, GHCR)
+- [docs/oracle-vm-stack.md](docs/oracle-vm-stack.md) — Auto-hospedaje en Oracle Cloud VM
+- [docs/audits/](docs/audits/README.md) — Auditoría completa: seguridad, rendimiento, accesibilidad, UI/UX
+- [CLAUDE.md](CLAUDE.md) — Convenciones: ramas, commits, calidad de código, tests
 
 ---
 

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -1,22 +1,144 @@
-# Building and running your application
+# Docker — Guía del stack de contenedores
 
-When you're ready, start your application by running:
-`docker compose up --build`.
+Esta guía documenta el stack Docker real del proyecto: desarrollo local con Docker Compose, la anatomía de la imagen, el despliegue de producción (Compose con nginx/certbot o Heroku container stack) y las imágenes publicadas en GHCR.
 
-Your application will be available at http://localhost:8000.
+Para las convenciones generales del proyecto (ramas, commits, tests) ver [../CLAUDE.md](../CLAUDE.md).
 
-# Deploying your application to the cloud
+---
 
-First, build your image, e.g.: `docker build -t myapp .`.
-If your cloud uses a different CPU architecture than your development
-machine (e.g., you are on a Mac M1 and your cloud provider is amd64),
-you'll want to build the image for that platform, e.g.:
-`docker build --platform=linux/amd64 -t myapp .`.
+## Resumen del stack
 
-Then, push it to your registry, e.g. `docker push myregistry.com/myapp`.
+| Componente | Definición | Detalle |
+|-----------|-----------|---------|
+| Imagen web | `Dockerfile` | `python:3.12-slim-bookworm`, Gunicorn, `collectstatic` en build |
+| Compose dev | `docker-compose.yml` | Servicios `db` (Postgres 16) + `web` (runserver) |
+| Compose prod | `docker-compose.prod.yml` | `db` + `web` (imagen GHCR) + `nginx` + `certbot` |
+| Heroku | `heroku.yml` | Build de la imagen `web`, `migrate` en release, Gunicorn en run |
+| Registro | GHCR | `ghcr.io/sandovaldavid/auctions` (publicada por CI) |
+| Estáticos | WhiteNoise | `CompressedManifestStaticFilesStorage` (ver `commerce/settings.py`) |
 
-Consult Docker's [getting started](https://docs.docker.com/go/get-started-sharing/)
-docs for more detail on building and pushing.
+---
 
-# References
-* [Docker's Python guide](https://docs.docker.com/language/python/)
+## Desarrollo local
+
+Levantar Django + PostgreSQL:
+
+```bash
+docker compose up --build
+```
+
+El servicio `web` aplica migraciones y arranca `runserver` automáticamente (ver el `command` en `docker-compose.yml`). La app queda en http://localhost:8000.
+
+Comandos útiles:
+
+```bash
+# Aplicar migraciones manualmente
+docker compose exec web python manage.py migrate
+
+# Crear superusuario (para el admin de Django)
+docker compose exec web python manage.py createsuperuser
+
+# Ver logs
+docker compose logs -f web
+
+# Detener y eliminar contenedores (conserva el volumen de datos)
+docker compose down
+```
+
+El servicio `db` expone PostgreSQL 16 en el puerto `5432` con la base `auctions_dev` (usuario `auctions`), y monta el volumen `postgres_data` para persistir datos entre reinicios. Incluye un `healthcheck` con `pg_isready`; `web` espera a que la base esté sana (`depends_on: condition: service_healthy`).
+
+---
+
+## Anatomía del `Dockerfile`
+
+```dockerfile
+FROM python:3.12-slim-bookworm AS base
+```
+
+- **Base slim** (`python:3.12-slim-bookworm`) para reducir tamaño; se instalan `libpq-dev` y `build-essential` para compilar `psycopg2` y luego se limpia el cache de apt.
+- **`PYTHONDONTWRITEBYTECODE=1` / `PYTHONUNBUFFERED=1`** — sin `.pyc` y logs sin buffer (mejor para contenedores).
+- **`collectstatic --noinput`** en tiempo de build: los estáticos quedan servidos por WhiteNoise desde la propia imagen, sin necesidad de un servidor de archivos separado en dev.
+- **Gunicorn** como servidor WSGI: `--workers 3 --timeout 120`, escuchando en `${PORT:-8000}` (Heroku inyecta `PORT`).
+
+> Nota: las dependencias `numpy`/`pandas`/`scikit-learn` viven en `requirements-dev.txt` y **no** se instalan en esta imagen. Los módulos de analítica que las importan fallarían en producción — ver [audits/code-quality.md](audits/code-quality.md) (CODE-002).
+
+---
+
+## Producción con Docker Compose (Oracle VM / self-hosting)
+
+`docker-compose.prod.yml` define el stack completo para auto-hospedaje:
+
+- **`db`** — Postgres 16, configuración vía `.env.prod`, volumen `postgres_data_prod`.
+- **`web`** — usa la imagen publicada `ghcr.io/sandovaldavid/auctions:latest` (no reconstruye), monta volúmenes de `staticfiles` y `media`, expone `8000` solo internamente.
+- **`nginx`** — `nginx:1.27-alpine` como reverse proxy y terminación TLS en `80`/`443`, sirviendo estáticos/media desde volúmenes compartidos (config en `nginx/nginx.conf`).
+- **`certbot`** — emisión y renovación automática de certificados Let's Encrypt (renueva cada 12 h).
+
+```bash
+# Requiere un archivo .env.prod con POSTGRES_*, DOMAIN, CERTBOT_EMAIL y las vars de Django
+docker compose -f docker-compose.prod.yml up -d
+```
+
+Este stack se corresponde con la guía de [oracle-vm-stack.md](oracle-vm-stack.md) para la VM Always-Free de Oracle.
+
+---
+
+## Producción en Heroku (container stack)
+
+`heroku.yml` describe el despliegue actual de producción:
+
+```yaml
+build:
+  docker:
+    web: Dockerfile
+release:
+  image: web
+  command: python manage.py migrate --no-input
+run:
+  web: gunicorn commerce.wsgi:application --bind 0.0.0.0:$PORT --workers 3 --timeout 120
+```
+
+- La fase **`release`** aplica migraciones automáticamente en cada deploy.
+- El deploy lo dispara el workflow `cd-production.yml` en cada push a `main` (build + push a GHCR + `heroku container:push/release`).
+- Cambiar la app al stack de contenedores (una sola vez): `heroku stack:set container -a <nombre-app>`.
+
+---
+
+## Imágenes en GHCR
+
+El CI publica la imagen web en GitHub Container Registry:
+
+```bash
+# La imagen de producción
+docker pull ghcr.io/sandovaldavid/auctions:latest
+
+# También se etiqueta por SemVer y por SHA de commit (ver cd-production.yml)
+```
+
+`cd-develop.yml` publicaría la etiqueta `:develop` cuando el stack de staging (Oracle VM/k3s) esté activo; actualmente está deshabilitado (`workflow_dispatch`).
+
+---
+
+## Variables de entorno
+
+Copiar `.env.example` a `.env` (para ejecución sin Compose) o definirlas en `.env.prod` (Compose de producción):
+
+| Variable | Descripción | Default dev |
+|---------|-------------|-------------|
+| `SECRET_KEY` | Clave secreta de Django | (requerida en prod) |
+| `DEBUG` | Modo debug | `False` |
+| `DATABASE_URL` | URL de PostgreSQL (`postgres://user:pass@host:5432/db`) | SQLite si no está |
+| `DJANGO_ALLOWED_HOSTS` | Hosts permitidos, separados por coma | `127.0.0.1,localhost` |
+
+> El `docker-compose.yml` de desarrollo inyecta estas variables inline (incluida una `SECRET_KEY` de desarrollo). En producción **nunca** debe usarse el valor por defecto de `SECRET_KEY` — ver [audits/security.md](audits/security.md) (SEC-008).
+
+---
+
+## Troubleshooting
+
+| Síntoma | Causa probable | Acción |
+|---------|----------------|--------|
+| `web` no arranca, espera a `db` | La base aún no pasa el `healthcheck` | Esperar; revisar `docker compose logs db` |
+| `psycopg2` falla al construir | Falta `libpq-dev`/`build-essential` | Ya incluidos en el `Dockerfile`; reconstruir con `--build` |
+| Estáticos no se ven | `collectstatic` no corrió o `STATIC_ROOT` vacío | La imagen corre `collectstatic` en build; reconstruir |
+| `ModuleNotFoundError: numpy` | Módulo de analítica en imagen de prod | Ver [audits/code-quality.md](audits/code-quality.md) (CODE-002) |
+| CSRF/redirect loop tras nginx | Falta `SECURE_PROXY_SSL_HEADER`/`CSRF_TRUSTED_ORIGINS` | Ver [audits/security.md](audits/security.md) (SEC-010) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,24 @@
+# Documentación — Sitio de Subastas
+
+Índice de la documentación del proyecto. Para las convenciones de desarrollo (stack, ramas, commits, calidad, tests) ver [../CLAUDE.md](../CLAUDE.md); para la visión general y la instalación ver [../README.md](../README.md).
+
+## Guías
+
+| Documento | Descripción | Audiencia |
+|-----------|-------------|-----------|
+| [Docker.md](Docker.md) | Stack de contenedores: desarrollo local, imagen, producción (Compose + nginx/certbot y Heroku), GHCR | Desarrollo / DevOps |
+| [oracle-vm-stack.md](oracle-vm-stack.md) | Auto-hospedaje en la VM Always-Free de Oracle (k3s + Argo CD o Docker Compose + Portainer) y stack de observabilidad | DevOps / Infra |
+
+## Auditoría del proyecto
+
+Revisión estática completa (2026-07-02, commit `784f51a`): 70 hallazgos con `archivo:línea`, severidad y roadmap de remediación.
+
+| Documento | Descripción |
+|-----------|-------------|
+| [audits/README.md](audits/README.md) | Resumen ejecutivo: metodología, taxonomía, conteos por área, top 10 y roadmap de PRs |
+| [audits/security.md](audits/security.md) | Seguridad (18): condición de carrera en pujas, CSRF vía GET, registro sin validadores, XSS |
+| [audits/code-quality.md](audits/code-quality.md) | Calidad de código (10): analítica rota en Postgres, dependencias ausentes, modelos sin constraints |
+| [audits/accessibility.md](audits/accessibility.md) | Accesibilidad y contraste (14): variables CSS rotas, 11 pares que fallan WCAG AA, skip-link ausente |
+| [audits/performance.md](audits/performance.md) | Rendimiento (8): N+1, conteos multiplicados, agregaciones en Python, índices ausentes |
+| [audits/ui-ux.md](audits/ui-ux.md) | UI/UX (12): UI muerta, inconsistencias de versión/formato, acción destructiva sin confirmación |
+| [audits/testing-and-ci.md](audits/testing-and-ci.md) | Tests y CI/CD (8): cobertura ciega en módulos frágiles, suite legacy duplicada, gaps de CI |

--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -1,0 +1,78 @@
+# Auditoría completa del proyecto — Resumen ejecutivo
+
+> **Fecha:** 2026-07-02 · **Commit:** `784f51a` · **Rama:** `develop`
+
+Este directorio contiene la revisión completa del sitio de subastas (Django 5.1) en seis áreas: seguridad, calidad de código, accesibilidad/contraste, rendimiento, UI/UX y tests/CI. Se documentaron **70 hallazgos** con ubicación `archivo:línea`, severidad y recomendación de remediación. Esta auditoría es **solo documentación**; las correcciones se abordarán en PRs separados según el roadmap de abajo.
+
+## Alcance y metodología
+
+Análisis **estático** más herramientas de línea de comandos, sin servidor en vivo ni navegador:
+
+- **Seguridad:** lectura de código + `bandit -r auctions/ commerce/ -ll` + `safety check -r requirements.txt`.
+- **Calidad de código:** lectura de código + `ruff check .` + `black --check .` + `mypy auctions/`.
+- **Contraste:** cálculo matemático de ratios WCAG 2.1 con las mismas fórmulas de `tests/unit/test_theme_colors.py:12-29` (script `wcag_ratios.py` sobre 23 pares de color).
+- **Rendimiento:** identificación de patrones de consulta ORM/plantillas por lectura (sin profiling).
+- **Tests/CI:** `pytest --cov` + revisión de `pyproject.toml` y `.github/workflows/`.
+
+**Qué NO se hizo** (candidato a una segunda pasada): auditoría en vivo con `axe-core`/Lighthouse (el fixture `tests/e2e/fixtures/axe.min.js` ya está preparado), profiling real de consultas con `django-debug-toolbar`, y pruebas de penetración dinámicas.
+
+## Taxonomía de severidad
+
+| Severidad | Criterio |
+|-----------|----------|
+| **Crítico** | Explotable, con pérdida de datos/dinero, o rotura garantizada en producción (XSS, condición de carrera con dinero, `ImportError` en prod, fuga de datos sin auth). |
+| **Alto** | Riesgo real de seguridad o fallo funcional visible al usuario (CSRF, contraseñas sin validar, contraste ilegible, N+1 severo). |
+| **Medio** | Deuda que degrada calidad, mantenibilidad o rendimiento sin fallo inmediato. |
+| **Bajo** | Pulido, consistencia y limpieza. |
+
+Esfuerzo estimado por hallazgo: **S** (pequeño), **M** (medio), **L** (grande).
+
+## Resumen por área
+
+| Área | Documento | Crítico | Alto | Medio | Bajo | Total |
+|------|-----------|:---:|:---:|:---:|:---:|:---:|
+| Seguridad | [security.md](security.md) | 4 | 6 | 5 | 3 | 18 |
+| Calidad de código | [code-quality.md](code-quality.md) | 2 | 3 | 3 | 2 | 10 |
+| Accesibilidad y contraste | [accessibility.md](accessibility.md) | 1 | 5 | 6 | 2 | 14 |
+| Rendimiento | [performance.md](performance.md) | 0 | 3 | 3 | 2 | 8 |
+| UI/UX | [ui-ux.md](ui-ux.md) | 0 | 3 | 5 | 4 | 12 |
+| Tests y CI/CD | [testing-and-ci.md](testing-and-ci.md) | 0 | 3 | 3 | 2 | 8 |
+| **Total** | | **7** | **23** | **25** | **15** | **70** |
+
+## Top 10 hallazgos por severidad
+
+1. **SEC-001** — Condición de carrera en `place_bid` (pujas concurrentes, `auctions/models.py:40-45`).
+2. **SEC-002** — `place_bid` acepta pujas por debajo del precio inicial (`auctions/models.py:40-45`).
+3. **CODE-001** — Analítica rota en PostgreSQL: `User` equivocado + SQL solo-SQLite (`auctions/analytics.py`).
+4. **CODE-002** — `numpy`/`pandas` ausentes de `requirements.txt`: `ImportError` en producción.
+5. **SEC-003** — `register` omite los validadores de contraseña y lanza 500 (`auctions/views.py:47-72`).
+6. **SEC-004** — `test_admin_dashboard` filtra conteos sin autenticación (`auctions/admin_views.py:420`).
+7. **A11Y-001** — 87 variables CSS rotas en el `components.css` cargado (colores intencionales no se aplican).
+8. **SEC-009** — Datos de BD con `|safe` dentro de `<script>` admin: XSS almacenado potencial.
+9. **SEC-005/006/007** — Mutaciones de estado vía GET (CSRF) en `close_auction`, `watchlist_remove`, `logout`.
+10. **CODE-003** — `Listing.winner` con `on_delete=CASCADE` (borrar usuario elimina el listing).
+
+## Roadmap de remediación
+
+PRs sugeridos, alineados con la estrategia de ramas de `CLAUDE.md` (`fix/*`, `refactor/*`, `chore/*` → `develop`, con **squash merge**), en orden de prioridad. Cada hallazgo indica su PR en la columna correspondiente de su documento.
+
+| Prioridad | Rama sugerida | Hallazgos incluidos |
+|:---:|---|---|
+| 1 | `fix/security-critical` | SEC-001, SEC-002, SEC-003, SEC-005, SEC-006, SEC-007, SEC-008, SEC-011, CODE-004 |
+| 1 | `fix/analytics-postgres` | CODE-001, CODE-002 |
+| 2 | `fix/admin-routing` | SEC-004 |
+| 2 | `fix/xss-templates` | SEC-009, SEC-013, SEC-014 |
+| 2 | `fix/a11y-css-variables` | A11Y-001..007, A11Y-010, TEST-006 |
+| 3 | `chore/settings-hardening` | SEC-010, SEC-012, SEC-015, SEC-016, SEC-017 |
+| 3 | `refactor/model-constraints` | CODE-003, CODE-005, CODE-006, PERF-006 |
+| 3 | `refactor/query-performance` | PERF-001, PERF-002, PERF-003, PERF-004, PERF-005, PERF-007, PERF-008 |
+| 4 | `chore/frontend-consistency` | UX-001..012, A11Y-009, A11Y-011..014, SEC-018 |
+| 4 | `chore/deps-and-tests` | CODE-007, CODE-008, CODE-009, CODE-010, TEST-001..005, TEST-007, TEST-008 |
+
+## Notas de evidencia
+
+- `bandit`: sin hallazgos en código de aplicación (13 avisos Low, todos en la suite legacy `auctions/tests/`).
+- `safety`: 0 vulnerabilidades reportadas, pero 35 ignoradas por dependencias sin fijar (ver CODE-007).
+- `ruff`/`black`: limpios. `mypy`: 1 error real (CODE-010).
+- `pytest`: 85 tests pasan, 81 % de cobertura (con módulos frágiles excluidos vía `omit`; ver TEST-002).
+- Contraste: 23 pares evaluados, 11 fallan WCAG AA (tabla completa en [accessibility.md](accessibility.md)).

--- a/docs/audits/accessibility.md
+++ b/docs/audits/accessibility.md
@@ -1,0 +1,127 @@
+# Auditoría de Accesibilidad y Contraste — Sitio de Subastas
+
+> **Fecha:** 2026-07-02 · **Commit:** `784f51a` · **Rama:** `develop`
+> **Método:** análisis estático de plantillas/CSS + cálculo matemático de ratios de contraste WCAG 2.1 (mismas fórmulas que `tests/unit/test_theme_colors.py:12-29`). Sin auditoría en vivo (axe/Lighthouse). Ver metodología en [README.md](README.md).
+
+## Resumen
+
+Se identificaron **14 hallazgos** de accesibilidad. El más estructural es que el `components.css` cargado referencia **22 variables CSS distintas que no existen** (87 referencias `var()` rotas), mientras el sistema de variables correcto vive en archivos CSS huérfanos que ningún template enlaza. Sobre contraste, de **23 pares** de color evaluados matemáticamente, **11 fallan** el mínimo WCAG AA, concentrados en badges e íconos de Bootstrap con texto blanco sobre fondos claros y en botones outline que usan colores semánticos crudos como texto.
+
+| Severidad | Cantidad |
+|-----------|----------|
+| Crítico   | 1 |
+| Alto      | 5 |
+| Medio     | 6 |
+| Bajo      | 2 |
+
+## Hallazgos
+
+| ID | Severidad | Ubicación | Resumen | Esfuerzo | PR sugerido |
+|----|-----------|-----------|---------|----------|-------------|
+| A11Y-001 | Crítico | `auctions/static/css/components.css` (87 refs) | 22 variables CSS indefinidas en el archivo cargado; los colores correctos están en `static/css/components/{card,alert,footer,pagination}.css` huérfanos (sin enlazar) | L | `fix/a11y-css-variables` |
+| A11Y-002 | Alto | `admin/users.html:87`, `reports.html:206,294`, `listings.html:145` … | Badges `bg-warning`/`bg-info` con texto blanco: 1.63:1 y 1.96:1 (fallo severo) | M | `fix/a11y-css-variables` |
+| A11Y-003 | Alto | `dashboard.html:153`, `listing_detail.html:182`, admin | `text-warning`/`text-info` sobre blanco: 1.63:1 y 1.96:1 | M | `fix/a11y-css-variables` |
+| A11Y-004 | Alto | `pages/error-pages.css:237-240`, `auction.css:429-431`, `index.css:132` | Botones outline con color semántico crudo como texto: 2.15–3.76:1 | M | `fix/a11y-css-variables` |
+| A11Y-005 | Alto | `layout.css:27-45`, `layout.js:172-184` | Skip-link con CSS + JS pero **sin elemento `<a class="skip-link">` en el DOM**: usuarios de teclado sin salto al contenido | S | `fix/a11y-css-variables` |
+| A11Y-006 | Alto | `index.html`, `watchList.html`, `login.html`, `register.html`, `newAuctions.html` | Sin `<h1>`: las páginas empiezan en `h2`/`h3` | S | `fix/a11y-css-variables` |
+| A11Y-007 | Medio | `auctions/static/css/pages/auction.css:153-157` | `.bids-count` (`#d97706` sobre `#eff6ff`): 2.93:1, texto pequeño | S | `fix/a11y-css-variables` |
+| A11Y-008 | Medio | `errors/404.html:4` (y 400/403/500), `layout.html:4` | `lang="en"` en el layout pero contenido de páginas de error en español | S | `fix/a11y-css-variables` |
+| A11Y-009 | Medio | `components/card.html:91-94` | Enlace "View" con texto oculto bajo breakpoint `sm`: en móvil queda solo un ícono sin nombre accesible | S | `chore/frontend-consistency` |
+| A11Y-010 | Medio | `pages/login.css:76-80`, `pages/auction.css:201-205` | Anillo de foco eliminado (`box-shadow:none; border:none`): sin indicador de foco visible (WCAG 2.4.7) | S | `fix/a11y-css-variables` |
+| A11Y-011 | Medio | `admin/listings.html:161-171`, `users.html:134-144`, `listing_detail.html:114` | Controles solo-ícono en admin sin `aria-label` (solo `title`) | S | `chore/frontend-consistency` |
+| A11Y-012 | Medio | `index.html:16,35,45,57`, `card.html:7,12,17`, `auction.html:39,52` | Íconos Font Awesome decorativos sin `aria-hidden="true"` de forma consistente | S | `chore/frontend-consistency` |
+| A11Y-013 | Bajo | `components/alert.html:6` | `aria-live="assertive"` para todos los mensajes (incluidos success/info); debería ser `polite` salvo errores críticos | S | `chore/frontend-consistency` |
+| A11Y-014 | Bajo | `layout.html:9`, `admin/base.html:7` | `maximum-scale=5.0` en viewport: restringe el zoom del usuario | S | `chore/frontend-consistency` |
+
+## Tabla de contraste (WCAG 2.1, calculada)
+
+Ratios calculados con el script `wcag_ratios.py` (reutiliza `relative_luminance`/`contrast_ratio` de `tests/unit/test_theme_colors.py`). Umbral AA: 4.5:1 texto normal, 3.0:1 texto grande / componentes UI.
+
+| Par (fg sobre bg) | Ubicación | Ratio | Umbral | Resultado |
+|---|---|---|---|---|
+| Badge `bg-warning` + blanco (`#ffffff`/`#ffc107`) | `admin/users.html:87` +6 | 1.63:1 | 4.5:1 | **FALLA** |
+| Badge `bg-info` + blanco (`#ffffff`/`#0dcaf0`) | `admin/users.html:109` +6 | 1.96:1 | 4.5:1 | **FALLA** |
+| Badge `bg-success` + blanco (`#ffffff`/`#198754`) | `card.html:65`, `auction.html:51` | 4.53:1 | 4.5:1 | Pasa |
+| `text-warning` sobre blanco (`#ffc107`/`#ffffff`) | `dashboard.html:153` (8 usos) | 1.63:1 | 4.5:1 | **FALLA** |
+| `text-info` sobre blanco (`#0dcaf0`/`#ffffff`) | admin (9 usos) | 1.96:1 | 4.5:1 | **FALLA** |
+| `text-success` sobre blanco (`#198754`/`#ffffff`) | `listings.html:127-131` (20 usos) | 4.53:1 | 4.5:1 | Pasa |
+| `btn-outline-heart` (`#ef4444`/`#ffffff`) | `auction.css:429-431` | 3.76:1 | 4.5:1 | **FALLA** |
+| `btn-outline-custom` 404 (`#3b82f6`/`#ffffff`) | `error-pages.css:237` | 3.68:1 | 4.5:1 | **FALLA** |
+| `btn-outline-custom` 400 (`#f59e0b`/`#ffffff`) | `error-pages.css:238` | 2.15:1 | 4.5:1 | **FALLA** |
+| `btn-outline-custom` 403 (`#d97706`/`#ffffff`) | `error-pages.css:239` | 3.19:1 | 4.5:1 | **FALLA** |
+| `btn-outline-custom` 500 (`#ef4444`/`#ffffff`) | `error-pages.css:240` | 3.76:1 | 4.5:1 | **FALLA** |
+| `.filter-card .btn-outline-primary` (`#3b82f6`/`#ffffff`) | `index.css:132` | 3.68:1 | 4.5:1 | **FALLA** |
+| `.bids-count` (`#d97706`/`#eff6ff`) | `auction.css:153-157` | 2.93:1 | 4.5:1 | **FALLA** |
+| `.price-amount` (`#059669`/`#ffffff`) | `auction.css:140-143` (texto grande) | 3.77:1 | 3.0:1 | Pasa |
+| `--error-text` sobre blanco (`#dc2626`/`#ffffff`) | `variables.css:281` | 4.83:1 | 4.5:1 | Pasa |
+| `text-muted` (`#6b7280`/`#ffffff`) | 47 usos | 4.83:1 | 4.5:1 | Pasa |
+| `text-muted` sobre `#f9fafb` | fondo de página | 4.63:1 | 4.5:1 | Pasa |
+| Texto principal (`#111827`/`#ffffff`) | body | 17.74:1 | 4.5:1 | Pasa |
+| Badge categoría (`#1d4ed8`/`#dbeafe`) | `test_theme_colors.py` | 5.49:1 | 4.5:1 | Pasa |
+| Nav: blanco/`#2563eb` | `navigation.css:189` | 5.17:1 | 4.5:1 | Pasa |
+| Nav: blanco/`#1e40af` | extremo del gradiente | 8.72:1 | 4.5:1 | Pasa |
+| Ícono dorado sobre nav (`#fbbf24`/`#2563eb`) | `navigation.css:102` (decorativo) | 3.10:1 | 3.0:1 | Pasa |
+| Debug info (`#e5e7eb`/`#1f2937`) | `error-pages.css:209-210` | 11.86:1 | 4.5:1 | Pasa |
+
+**Total: 23 pares, 11 fallan WCAG AA.**
+
+## Detalle de hallazgos Crítico y Alto
+
+### A11Y-001 — Dos sistemas de variables CSS en conflicto
+
+- **Ubicación:** `auctions/static/css/components.css` (87 referencias rotas). Valores correctos en `static/css/components/{card,alert,footer,pagination}.css` (huérfanos, ningún template los enlaza).
+- **Descripción:** `variables.css` define el esquema `--primary-500`, `--success`, `--text-primary`, etc. Pero el `components.css` **cargado** usa un esquema legacy distinto (`--primary-color`, `--success-color`, `--card-bg`, `--price-color`, `--bid-color`, `--text-light`, `--gradient-primary`, …). Verificado por script: **87** referencias `var()` a **22** variables que no están definidas en ninguna parte. Esas declaraciones son inválidas y caen al valor heredado/inicial.
+- **Escenario de fallo:** los colores de acento de cards, footer, paginación y las barras de alerta no se aplican; el texto que debería ser azul de marca se renderiza como gris de cuerpo heredado (`--text-primary #111827`). Cualquier medición "de diseño" del contraste es engañosa porque el color intencional no llega a pintarse.
+- **Recomendación:** unificar en el sistema de `variables.css`. O bien enlazar los 4 archivos `components/*.css` (que ya contienen los colores correctos y con contraste corregido) y retirar los bloques legacy de `components.css`, o bien reescribir `components.css` para usar los nombres de `variables.css`. Resolver esto **antes** de tocar contraste, porque cambia qué colores están realmente en pantalla.
+
+### A11Y-002 / A11Y-003 — Badges y texto Bootstrap con contraste severo
+
+- **Ubicación:** badges en `admin/users.html:87,109`, `reports.html:206,243,288,294`, `listings.html:139,145`, `listing_detail.html:49,103,107`, `analytics.html:120,127`; utilidades `text-warning`/`text-info` en `dashboard.html:153`, `listing_detail.html:182`, y otros.
+- **Descripción:** Bootstrap 5.3 fija `color:#fff` en `.badge`. Usar `bg-warning` (`#ffc107`) o `bg-info` (`#0dcaf0`) sin `text-dark` produce texto blanco sobre amarillo/cian: **1.63:1** y **1.96:1**. Lo mismo con las utilidades de texto `text-warning`/`text-info` sobre fondo blanco.
+- **Escenario de fallo:** una etiqueta de estado "Pendiente" en amarillo con texto blanco es prácticamente ilegible; usuarios con baja visión no pueden leerla.
+- **Recomendación:** añadir `text-dark` a los badges `bg-warning`/`bg-info` (patrón ya usado correctamente en `auction.html:64`), y para las utilidades de texto usar tonos oscurecidos (p. ej. las variables `--*-text` de `variables.css`). Extender `tests/unit/test_theme_colors.py` para cubrir estos pares (ver [testing-and-ci.md](testing-and-ci.md), TEST-006).
+
+### A11Y-004 — Botones outline con colores semánticos crudos
+
+- **Ubicación:** `pages/error-pages.css:237-240` (`.btn-outline-custom` de las 4 páginas de error), `auction.css:429-431` (`.btn-outline-heart`, botón "Add to Watchlist"), `index.css:132` (`.filter-card .btn-outline-primary`).
+- **Descripción:** el texto del botón usa el color semántico puro (`--warning #f59e0b`, `--info #3b82f6`, `--error #ef4444`) sobre blanco, con ratios de **2.15:1 a 3.76:1**, todos por debajo de 4.5:1.
+- **Escenario de fallo:** el botón "Volver" de la página 400 (amarillo, 2.15:1) es casi ilegible en reposo.
+- **Recomendación:** usar las variantes oscurecidas (`--*-dark`/`--*-text`) para el texto en reposo, manteniendo el color vivo solo para el fondo en `:hover` (donde el texto pasa a blanco y sí contrasta).
+
+### A11Y-005 — Skip-link sin elemento en el DOM
+
+- **Ubicación:** CSS en `layout.css:27-45` y `auctions/styles.css:116-130`; JS en `layout.js:172-184`; pero ningún template renderiza `<a class="skip-link">`.
+- **Descripción:** existen los estilos `.skip-link` y un handler de click que hace foco en `.skip-link`, pero el elemento no está en el DOM (grep: cero coincidencias en templates). Además `<main id="main-content">` (`layout.html:70`) no tiene `tabindex="-1"`, así que no es enfocable aunque el enlace existiera.
+- **Escenario de fallo:** un usuario de teclado no tiene forma de saltar la navegación e ir directo al contenido en cada página.
+- **Recomendación:** añadir `<a href="#main-content" class="skip-link">Saltar al contenido</a>` como primer elemento del `<body>` en `layout.html`, y `tabindex="-1"` en `<main>`.
+
+### A11Y-006 — Páginas sin `<h1>`
+
+- **Ubicación:** `index.html` (empieza en `h2.display-5`, `:15`), `watchList.html` (`h2`, `:16`), `newAuctions.html` (`h2`, `:17`), `login.html` (`h2`, `:18`), `register.html` (`h2`, `:18`).
+- **Descripción:** estas páginas no tienen un `<h1>`; la jerarquía arranca en `h2`/`h3`. Los lectores de pantalla usan el `h1` como ancla del contenido principal.
+- **Escenario de fallo:** un usuario que navega por encabezados no encuentra el título principal de la página de inicio.
+- **Recomendación:** promover el encabezado principal de cada página a `<h1>` (manteniendo las clases visuales `display-*` para el tamaño). Revisar también el salto h1→h4 en `auction.html:79,189`.
+
+## Evidencia
+
+Conteo de variables CSS indefinidas en el archivo cargado (`components.css`):
+
+```text
+referencias var() en components.css: 132
+referencias a variables INDEFINIDAS: 87
+variables indefinidas distintas: 22
+['--badge-ending', '--bg-accent', '--bg-hover', '--bg-main', '--bg-user',
+ '--bid-color', '--border-color', '--card-bg', '--danger-color',
+ '--gradient-primary', '--hover-shadow', '--info-color', '--price-color',
+ '--primary-color', '--primary-light', '--secondary-color', '--secondary-dark',
+ '--secondary-light', '--success-color', '--text-light', '--toggle-icon',
+ '--warning-color']
+```
+
+Ratios de contraste: ver la tabla arriba (23 pares, 11 fallos), generada con `wcag_ratios.py` sobre las mismas fórmulas WCAG 2.1 del test existente.
+
+## Referencias
+
+- La suite `tests/unit/test_theme_colors.py` ya valida contraste de forma estática; ampliarla para cubrir los 11 pares que fallan se detalla en [testing-and-ci.md](testing-and-ci.md) (TEST-006).
+- El `axe.min.js` presente en `tests/e2e/fixtures/` habilita una auditoría en vivo futura (fuera del alcance de este análisis estático) — ver [testing-and-ci.md](testing-and-ci.md) (TEST-004).
+- Los problemas de UI muerta y consistencia visual relacionados (formulario de filtros sin funcionar, versiones de Bootstrap divergentes) están en [ui-ux.md](ui-ux.md).

--- a/docs/audits/code-quality.md
+++ b/docs/audits/code-quality.md
@@ -1,0 +1,94 @@
+# Auditoría de Calidad de Código — Sitio de Subastas
+
+> **Fecha:** 2026-07-02 · **Commit:** `784f51a` · **Rama:** `develop`
+> **Método:** análisis estático (lectura de código + `ruff` + `black` + `mypy`), sin servidor en vivo. Ver metodología en [README.md](README.md).
+
+## Resumen
+
+Se identificaron **10 hallazgos** de calidad de código. `ruff` y `black` salen limpios y `mypy` reporta un único error real; los problemas graves son de correctitud en tiempo de ejecución que las herramientas estáticas no detectan: el módulo de analítica importa el modelo `User` equivocado y usa SQL exclusivo de SQLite (rompe en la BD PostgreSQL de producción), y varios módulos importan `numpy`/`pandas` que no están en `requirements.txt` (fallo de importación en la imagen de producción).
+
+| Severidad | Cantidad |
+|-----------|----------|
+| Crítico   | 2 |
+| Alto      | 3 |
+| Medio     | 3 |
+| Bajo      | 2 |
+
+## Hallazgos
+
+| ID | Severidad | Ubicación | Resumen | Esfuerzo | PR sugerido |
+|----|-----------|-----------|---------|----------|-------------|
+| CODE-001 | Crítico | `auctions/analytics.py:19,84,93,102,283,296` | Importa `django.contrib.auth.models.User` (no el swapped) y usa `.extra()` con SQL solo-SQLite (`date()`, `strftime()`): rompe en PostgreSQL | L | `fix/analytics-postgres` |
+| CODE-002 | Crítico | `auctions/data_utils.py:8`, `management/commands/generate_reports.py:86` | Importan `numpy`/`pandas`, ausentes de `requirements.txt` (solo en `requirements-dev.txt`): `ImportError` en imagen de producción | M | `fix/analytics-postgres` |
+| CODE-003 | Alto | `auctions/models.py:23-29` | `Listing.winner` con `on_delete=CASCADE`: borrar un usuario ganador elimina en cascada el listing | S | `refactor/model-constraints` |
+| CODE-004 | Alto | `auctions/views.py:147,169-170` | `.get()` desnudos (`Listing`, `Watchlist`) sin `get_object_or_404`: `DoesNotExist`→500 con IDs inválidos | S | `fix/security-critical` |
+| CODE-005 | Alto | `auctions/models.py` (todos los modelos) | Sin `class Meta`: sin índices, sin `constraints`, sin `ordering`, sin `unique_together` en `Watchlist(user, listing)` | M | `refactor/model-constraints` |
+| CODE-006 | Medio | `auctions/forms.py:30-36` | Unicidad de `title` solo en el form (`filter(...).exists()`): TOCTOU y sustituye a un `unique=True` de BD ausente | S | `refactor/model-constraints` |
+| CODE-007 | Medio | `requirements.txt` (global) | Todas las dependencias con `>=` y sin lockfile: builds no reproducibles | S | `chore/deps-and-tests` |
+| CODE-008 | Medio | `auctions/middleware.py:64-86`, `commerce/settings.py:45` | `Custom404Middleware` guarda sobre `settings.USE_CUSTOM_ERROR_HANDLERS`, que no existe: código muerto | S | `chore/deps-and-tests` |
+| CODE-009 | Bajo | `commerce/settings.py:30`, `auctions/admin.py` | `django-import-export` instalado pero sin uso (los `ModelAdmin` son planos) | S | `chore/deps-and-tests` |
+| CODE-010 | Bajo | `commerce/settings.py:84` | `mypy`: asignación incompatible `DBConfig` a `dict[str, str]` en la config de base de datos | S | `chore/deps-and-tests` |
+
+## Detalle de hallazgos Crítico y Alto
+
+### CODE-001 — Analítica rota en PostgreSQL
+
+- **Ubicación:** `auctions/analytics.py:19` (import) y `:84,93,102,283,296` (`.extra()`).
+- **Descripción:** dos problemas combinados. (1) `from django.contrib.auth.models import User` importa el modelo de auth estándar en vez del swapped `auctions.User` (`AUTH_USER_MODEL`, `settings.py:90`); las anotaciones `User.objects.annotate(Count("bids"|"listings"|"comments"))` (`analytics.py:137-152`) apuntan a relaciones que no existen en ese modelo → `FieldError`/`OperationalError`. (2) `.extra(select={...})` usa `date(created)` y `strftime(...)`, funciones **exclusivas de SQLite** que no existen en PostgreSQL; además `.extra()` está deprecado.
+- **Escenario de fallo:** en producción (PostgreSQL, `settings.py:82-88`) `get_time_series_data`/`get_market_trends` lanzan excepción. El dashboard "sobrevive" solo porque `admin_dashboard` envuelve todo en `try/except` (`admin_views.py:58`), lo que enmascara el fallo y deja las gráficas vacías.
+- **Recomendación:** importar `from django.contrib.auth import get_user_model` y sustituir `.extra()` por `TruncDate`/`TruncMonth` (`django.db.models.functions`), que son agnósticos de motor. Cubrir con tests (este módulo está en la lista `omit` de coverage — ver [testing-and-ci.md](testing-and-ci.md), TEST-002).
+
+### CODE-002 — `numpy`/`pandas` ausentes en producción
+
+- **Ubicación:** `auctions/data_utils.py:8` (`import numpy` incondicional), `management/commands/generate_reports.py:86` (`import pandas`).
+- **Descripción:** el stack de datos/ML (`pandas`, `numpy`, `scikit-learn`, `plotly`) está en `requirements-dev.txt`, **no** en `requirements.txt`. `analytics.py:8-17` protege sus imports con `try/except` y degrada, pero `data_utils.py` importa `numpy` sin guardia y el comando de gestión importa `pandas`. La imagen de producción se construye solo desde `requirements.txt`.
+- **Escenario de fallo:** en la imagen de producción, importar `data_utils` o ejecutar `manage.py generate_reports` produce `ModuleNotFoundError: No module named 'numpy'`/`'pandas'`.
+- **Recomendación:** decidir si la analítica es funcionalidad de producción. Si lo es, mover esas dependencias a `requirements.txt`; si no, aislar el módulo de comandos y proteger los imports. Alinear con la decisión de arquitectura de `CLAUDE.md` (analítica como fase futura).
+
+### CODE-003 — `Listing.winner` con borrado en cascada
+
+- **Ubicación:** `auctions/models.py:23-29`.
+- **Descripción:** `winner = models.ForeignKey(User, on_delete=models.CASCADE, ...)`. Borrar al usuario que ganó una subasta elimina en cascada el propio `Listing` (registro histórico de la venta).
+- **Escenario de fallo:** se borra una cuenta que ganó 5 subastas → desaparecen los 5 listings y su historial de pujas.
+- **Recomendación:** cambiar a `on_delete=models.SET_NULL` (el campo ya es `null=True, blank=True`). Requiere una migración.
+
+### CODE-004 — `.get()` desnudos producen 500
+
+- **Ubicación:** `auctions/views.py:147` (`Listing.objects.get(pk=...)` en `watchlist`), `:169-170` (`Listing`/`Watchlist` en `watchlist_remove`).
+- **Descripción:** mientras otras vistas usan `get_object_or_404` (`views.py:102,114,178,224`), estas dos usan `.get()` directo, que lanza `DoesNotExist` (HTTP 500) ante un ID inexistente en vez de un 404 limpio.
+- **Escenario de fallo:** `POST /watchlist/999999` con un ID inexistente devuelve 500 en lugar de 404.
+- **Recomendación:** sustituir por `get_object_or_404`. Se solapa con SEC-006 (esas mismas vistas también deben pasar a POST).
+
+### CODE-005 — Modelos sin `Meta`, índices ni constraints
+
+- **Ubicación:** `auctions/models.py` (los cinco modelos).
+- **Descripción:** ningún modelo declara `class Meta`. Consecuencias: (1) sin índices de BD en columnas de filtro/orden calientes (`Listing.active`, `category`, `created`; ver [performance.md](performance.md), PERF-006); (2) sin `CheckConstraint` para `starting_bid >= 0`, `amount > 0` o `current_bid >= starting_bid` (toda la validación es a nivel de app); (3) sin `UniqueConstraint`/`unique_together` en `Watchlist(user, listing)`, por lo que son posibles filas duplicadas (solo evitadas de casualidad por `get_or_create` en `views.py:148`); (4) sin `ordering` por defecto.
+- **Escenario de fallo:** una segunda ruta que cree `Watchlist` sin `get_or_create` genera duplicados; una puja negativa insertada por el ORM/admin no es rechazada por la BD.
+- **Recomendación:** añadir `Meta` con `indexes`, `constraints` (`CheckConstraint`) y `UniqueConstraint` en `Watchlist`. Agrupar con PERF-006 en `refactor/model-constraints`.
+
+## Evidencia
+
+`ruff check . --statistics` y `black --check .` — limpios:
+
+```text
+=== ruff check . --statistics ===
+(sin hallazgos)
+
+=== black --check . ===
+All done! ✨ 🍰 ✨
+45 files would be left unchanged.
+```
+
+`mypy auctions/` — un único error (CODE-010):
+
+```text
+commerce/settings.py:84: error: Incompatible types in assignment
+  (expression has type "DBConfig", target has type "dict[str, str]")  [assignment]
+Found 1 error in 1 file (checked 26 source files)
+```
+
+## Referencias
+
+- CODE-001 y CODE-002 comparten el PR sugerido `fix/analytics-postgres` porque ambos atañen a la cadena de analítica.
+- CODE-005 (índices/constraints) se detalla desde la perspectiva de rendimiento en [performance.md](performance.md) (PERF-006).
+- CODE-004 se solapa con las mutaciones-vía-GET de [security.md](security.md) (SEC-006).

--- a/docs/audits/performance.md
+++ b/docs/audits/performance.md
@@ -1,0 +1,70 @@
+# Auditoría de Rendimiento — Sitio de Subastas
+
+> **Fecha:** 2026-07-02 · **Commit:** `784f51a` · **Rama:** `develop`
+> **Método:** análisis estático de patrones de consulta ORM y plantillas (sin profiling en vivo ni `django-debug-toolbar` con datos reales). Ver metodología en [README.md](README.md).
+
+## Resumen
+
+Se identificaron **8 hallazgos** de rendimiento. Los patrones dominantes son consultas N+1 sin `select_related`/`prefetch_related` y agregaciones hechas en Python en vez de en la base de datos. Dos de ellos afectan al panel de administración con un coste que crece linealmente con el número de usuarios. La ausencia de índices en las columnas de filtro/orden calientes amplifica todo lo anterior.
+
+| Severidad | Cantidad |
+|-----------|----------|
+| Crítico   | 0 |
+| Alto      | 3 |
+| Medio     | 3 |
+| Bajo      | 2 |
+
+## Hallazgos
+
+| ID | Severidad | Ubicación | Resumen | Esfuerzo | PR sugerido |
+|----|-----------|-----------|---------|----------|-------------|
+| PERF-001 | Alto | `auctions/admin_views.py:42-47,170-174` | `Count("bids") + Count("listings") + Count("comments")` sin `distinct=True`: conteos multiplicados por fan-out de JOINs | S | `refactor/query-performance` |
+| PERF-002 | Alto | `auctions/data_utils.py:125-147` | `generate_user_activity_report` itera todos los usuarios con ~5 `.count()` cada uno: O(N·5) consultas | M | `refactor/query-performance` |
+| PERF-003 | Alto | `auctions/admin_views.py:326-408` | `admin_export_data` exporta todos los listings/bids/users sin límite ni paginación: memoria no acotada | M | `refactor/query-performance` |
+| PERF-004 | Medio | `auctions/views.py:103`, `auction.html:230` | N+1 en comentarios: `auction.comments.all()` sin `select_related("user")` | S | `refactor/query-performance` |
+| PERF-005 | Medio | `auctions/views.py:210-216` | Query `distinct()` de categorías en cada request, sin caché ni índice en `category` | S | `refactor/query-performance` |
+| PERF-006 | Medio | `auctions/models.py` (todos) | Sin índices de BD en `active`, `category`, `created`, `amount` (columnas de filtro/orden) | M | `refactor/model-constraints` |
+| PERF-007 | Bajo | `auctions/data_utils.py:171-176` | `generate_market_analysis` trae precios a Python y suma con `sum()/len()` en vez de `Avg` en BD | S | `refactor/query-performance` |
+| PERF-008 | Bajo | `auctions/views.py:16,157,197` | Listados sin `select_related("user")`: N+1 latente si la plantilla accede a `auction.user` | S | `refactor/query-performance` |
+
+## Detalle de hallazgos Alto
+
+### PERF-001 — Conteos multiplicados por fan-out de JOINs
+
+- **Ubicación:** `auctions/admin_views.py:42-47` (`top_users` en el dashboard) y `:170-174` (`admin_users`).
+- **Descripción:** `User.objects.annotate(total_activity=Count("bids") + Count("listings") + Count("comments"))` combina varios `Count` sobre relaciones distintas en una sola query. Sin `distinct=True`, cada JOIN multiplica las filas de los otros (producto cartesiano), inflando los conteos. Igual patrón en `admin_users` (`listings_count`, `bids_count`, `comments_count`).
+- **Escenario de fallo:** un usuario con 3 listings y 4 pujas puede reportar `listings_count = 12` en vez de 3, porque el JOIN con pujas duplica las filas de listings.
+- **Recomendación:** usar `Count("bids", distinct=True)` en cada anotación, o separar las anotaciones con subconsultas (`Subquery`/`Count` independientes). Añadir un test que verifique los conteos con datos conocidos.
+
+### PERF-002 — Reporte de actividad O(N·5)
+
+- **Ubicación:** `auctions/data_utils.py:125-147` (más `calculate_engagement_score` en `:44-47`).
+- **Descripción:** el método itera sobre **cada** usuario y ejecuta ~5 `.count()`/`.filter().count()` por iteración. El total de consultas crece como O(N·5) sin paginación ni anotación.
+- **Escenario de fallo:** con 1.000 usuarios se ejecutan ~5.000 consultas para un solo reporte.
+- **Recomendación:** reemplazar el bucle por una única query con `annotate(Count(..., distinct=True))` y paginar. Nota: este módulo también tiene el import `numpy` no disponible en producción (ver [code-quality.md](code-quality.md), CODE-002).
+
+### PERF-003 — Exportación sin límite
+
+- **Ubicación:** `auctions/admin_views.py:326-408` (`admin_export_data`).
+- **Descripción:** construye la exportación cargando en memoria todos los listings, pujas y usuarios sin `iterator()`, límite ni streaming.
+- **Escenario de fallo:** con tablas grandes, la petición consume memoria proporcional al dataset completo y puede agotar el dyno de Heroku.
+- **Recomendación:** usar `QuerySet.iterator()` y `StreamingHttpResponse`, o paginar/segmentar la exportación.
+
+## Detalle de hallazgos Medio (destacado)
+
+### PERF-004 — N+1 en comentarios
+
+- **Ubicación:** `auctions/views.py:103` (`auction.comments.all()`), consumido en `auction.html:230` (`comment.user.username` por cada comentario).
+- **Descripción:** sin `select_related("user")`, cada comentario dispara una consulta adicional para su usuario. El mismo camino se recorre al re-renderizar tras `bid` (`views.py:138`).
+- **Escenario de fallo:** un listing con 50 comentarios genera 1 + 50 consultas.
+- **Recomendación:** `auction.comments.select_related("user").all()`.
+
+## Metodología y limitaciones
+
+Este análisis es estático: se identificaron los patrones por lectura del código ORM y de las plantillas, no midiendo tiempos ni número de queries en ejecución. Para cuantificarlos conviene una pasada futura con `django-debug-toolbar` (ya en `requirements-dev.txt`) o `assertNumQueries` en tests, sobre datos representativos. Los índices propuestos (PERF-006) deberían priorizarse tras confirmar los planes de consulta reales en PostgreSQL.
+
+## Referencias
+
+- PERF-006 (índices) se agrupa con las constraints de modelo en [code-quality.md](code-quality.md) (CODE-005), bajo el PR `refactor/model-constraints`.
+- PERF-002 comparte módulo con el problema de dependencias de [code-quality.md](code-quality.md) (CODE-002).
+- La falta de tests de rendimiento (`assertNumQueries`) se anota en [testing-and-ci.md](testing-and-ci.md) (TEST-007).

--- a/docs/audits/security.md
+++ b/docs/audits/security.md
@@ -1,0 +1,141 @@
+# Auditoría de Seguridad — Sitio de Subastas
+
+> **Fecha:** 2026-07-02 · **Commit:** `784f51a` · **Rama:** `develop`
+> **Método:** análisis estático (lectura de código + `bandit` + `safety`), sin servidor en vivo. Ver metodología en [README.md](README.md).
+
+## Resumen
+
+Se identificaron **18 hallazgos** de seguridad. Los más graves no dependen de vulnerabilidades en dependencias (bandit y safety salen limpios), sino de la lógica de la aplicación: una condición de carrera con dinero en `place_bid`, mutaciones de estado vía GET (bypaseables por CSRF), un endpoint de datos sin autenticación, y el registro de usuarios que evita por completo los validadores de contraseña de Django.
+
+| Severidad | Cantidad |
+|-----------|----------|
+| Crítico   | 4 |
+| Alto      | 6 |
+| Medio     | 5 |
+| Bajo      | 3 |
+
+## Hallazgos
+
+| ID | Severidad | Ubicación | Resumen | Esfuerzo | PR sugerido |
+|----|-----------|-----------|---------|----------|-------------|
+| SEC-001 | Crítico | `auctions/models.py:40-45` | `place_bid` sin transacción ni `select_for_update`: condición de carrera en pujas concurrentes | M | `fix/security-critical` |
+| SEC-002 | Crítico | `auctions/models.py:40-45` | `place_bid` no valida contra `starting_bid` cuando `current_bid is None`: se aceptan pujas por debajo del precio inicial | S | `fix/security-critical` |
+| SEC-003 | Crítico | `auctions/views.py:47-72` | `register` usa `create_user` con `request.POST` crudo: omite `AUTH_PASSWORD_VALIDATORS` (contraseñas débiles) y lanza `KeyError`→500 si falta un campo | M | `fix/security-critical` |
+| SEC-004 | Crítico | `auctions/admin_views.py:420`, `auctions/urls.py:47` | `test_admin_dashboard` sin `@login_required`/`@user_passes_test` ni guard de `DEBUG`: fuga de conteos (usuarios, pujas, listings) a anónimos | S | `fix/admin-routing` |
+| SEC-005 | Alto | `auctions/views.py:176-191` | `close_auction` cambia estado en GET: CSRF vía `<img src>` con víctima autenticada | M | `fix/security-critical` |
+| SEC-006 | Alto | `auctions/views.py:166-173` | `watchlist_remove` muta estado en GET (invocado por `card.html:23`) | S | `fix/security-critical` |
+| SEC-007 | Alto | `auctions/views.py:42-44` | `logout` acepta GET: cierre de sesión forzable vía CSRF | S | `fix/security-critical` |
+| SEC-008 | Alto | `commerce/settings.py:14` | `SECRET_KEY` con fallback hardcodeado; sin validación de que exista en producción | S | `fix/security-critical` |
+| SEC-009 | Alto | `auctions/templates/auctions/admin/analytics.html:275,328`, `reports.html:340` | Datos de BD renderizados con `\|safe` dentro de `<script>`: XSS almacenado si un label deriva de entrada de usuario | M | `fix/xss-templates` |
+| SEC-010 | Alto | `commerce/settings.py:118-128` | Faltan `SECURE_SSL_REDIRECT`, `SECURE_PROXY_SSL_HEADER`, `CSRF_TRUSTED_ORIGINS` (detrás de proxy Heroku/nginx) | M | `chore/settings-hardening` |
+| SEC-011 | Medio | `auctions/views.py:26-27,49-54` | `login`/`register` leen `request.POST["campo"]` sin `.get()`: `KeyError`→500 con peticiones manipuladas | S | `fix/security-critical` |
+| SEC-012 | Medio | `commerce/settings.py` (global) | Sin configuración `LOGGING`: sin captura de errores ni auditoría en producción | M | `chore/settings-hardening` |
+| SEC-013 | Medio | `auctions/forms.py:52-61`, `auction.html:27`, `card.html:34` | `image` es URL de usuario permitiendo `http://`: contenido mixto + vector de tracking/phishing en `<img src>` | M | `fix/xss-templates` |
+| SEC-014 | Medio | `auctions/templates/auctions/layout.html:28-37`, `admin/base.html:19-25,132` | Recursos de CDN sin `integrity` (SRI); `plotly-latest.min.js` sin versión fija | M | `fix/xss-templates` |
+| SEC-015 | Medio | `commerce/settings.py:120` | `SECURE_BROWSER_XSS_FILTER` está obsoleto (header `X-XSS-Protection` desaconsejado) | S | `chore/settings-hardening` |
+| SEC-016 | Bajo | `commerce/settings.py:126-127` | `SESSION_COOKIE_SECURE`/`CSRF_COOKIE_SECURE` solo bajo `not DEBUG`; sin `SESSION_COOKIE_HTTPONLY` explícito ni `SESSION_COOKIE_AGE` | S | `chore/settings-hardening` |
+| SEC-017 | Bajo | `auctions/admin_views.py:58`, `error_views` | `except Exception as e` con `str(e)` al contexto de plantilla: potencial fuga de detalles internos | S | `chore/settings-hardening` |
+| SEC-018 | Bajo | `auctions/templates/auctions/errors/404.html:43` (y 400/500) | Las páginas de error enlazan a `admin_dashboard`, revelando la URL del panel a anónimos | S | `chore/frontend-consistency` |
+
+## Detalle de hallazgos Crítico y Alto
+
+### SEC-001 — Condición de carrera en `place_bid`
+
+- **Ubicación:** `auctions/models.py:40-45` (la vista `auctions/views.py:112-140` tampoco abre transacción).
+- **Descripción:** `place_bid` lee `self.current_bid`, compara, asigna y guarda sin `select_for_update()` ni `transaction.atomic()`. Dos pujas concurrentes leen el mismo `current_bid`, ambas pasan la comprobación y una sobrescribe silenciosamente a la otra.
+- **Escenario de fallo:** dos usuarios pujan \$110 y \$120 casi a la vez sobre un `current_bid` de \$100. Ambas transacciones leen \$100, ambas pasan la validación, la última en escribir gana; el importe intermedio y su `Bid` pueden quedar inconsistentes respecto a `current_bid`.
+- **Recomendación:** envolver la lectura-modificación-escritura en `transaction.atomic()` y recargar la fila con `Listing.objects.select_for_update().get(pk=...)` antes de comparar. Añadir un test de concurrencia (ver [testing-and-ci.md](testing-and-ci.md), TEST-001).
+
+```python
+from django.db import transaction
+
+def place_bid(self, user, bid_value):
+    with transaction.atomic():
+        listing = Listing.objects.select_for_update().get(pk=self.pk)
+        floor = listing.current_bid or listing.starting_bid
+        if bid_value <= floor:
+            raise ValidationError("The bid must be higher than the current bid.")
+        listing.current_bid = bid_value
+        listing.save(update_fields=["current_bid"])
+        Bid.objects.create(user=user, listing=listing, amount=bid_value)
+```
+
+### SEC-002 — `place_bid` no valida contra `starting_bid`
+
+- **Ubicación:** `auctions/models.py:40-45`.
+- **Descripción:** la única comprobación es `if self.current_bid is not None and bid_value <= self.current_bid`. Cuando aún no hay pujas (`current_bid is None`), la condición se salta por completo y se acepta cualquier valor positivo, incluso por debajo del precio inicial.
+- **Escenario de fallo:** un listing con `starting_bid=1000` y sin pujas acepta una primera puja de \$0.01; `BidForm.clean_amount` (`forms.py:69-75`) solo rechaza `<= 0`, no tiene acceso al listing para comparar contra el precio inicial.
+- **Recomendación:** usar `floor = current_bid or starting_bid` como en el snippet de SEC-001. Considerar además una `CheckConstraint` a nivel de BD (ver [code-quality.md](code-quality.md), CODE-005).
+
+### SEC-003 — `register` omite los validadores de contraseña y lanza 500
+
+- **Ubicación:** `auctions/views.py:47-72`.
+- **Descripción:** el registro no usa un `Form`/`UserCreationForm`; lee `request.POST["username"|"email"|"password"|"confirmation"]` directamente y llama `User.objects.create_user(...)`. Esto **evita** por completo `AUTH_PASSWORD_VALIDATORS` (definidos en `settings.py:92-99`), por lo que se aceptan contraseñas como `123`. Además, cualquier campo ausente produce `KeyError`→HTTP 500, y el email no se valida.
+- **Escenario de fallo:** un POST sin el campo `email` devuelve 500; un POST con `password=a` crea un usuario con contraseña de un carácter.
+- **Recomendación:** migrar el registro a `UserCreationForm` (o un `ModelForm` propio) que ejecute `validate_password()` y valide el email. Con ello se resuelve también SEC-011 para esta vista.
+
+### SEC-004 — Endpoint de datos sin autenticación
+
+- **Ubicación:** `auctions/admin_views.py:420` (`test_admin_dashboard`), ruta en `auctions/urls.py:47` (`test/admin/`).
+- **Descripción:** a diferencia del resto de vistas admin (decoradas con `@user_passes_test(is_superuser)`, verificado en `admin_views.py:15-23`) y de las otras vistas `test/*` que sí están protegidas por `DEBUG` en `error_views.py`, esta vista **no tiene decorador de auth ni guard de `DEBUG`** y renderiza `total_listings`, `active_listings`, `total_users` y `total_bids`.
+- **Escenario de fallo:** un anónimo visita `/test/admin/` en producción y obtiene los conteos del negocio.
+- **Recomendación:** eliminar la vista y su ruta, o al menos protegerla con `@user_passes_test(is_superuser)` y un guard `if not settings.DEBUG: raise Http404`.
+
+### SEC-005 / SEC-006 / SEC-007 — Mutaciones de estado vía GET (CSRF)
+
+- **Ubicación:** `close_auction` (`views.py:176-191`), `watchlist_remove` (`views.py:166-173`, invocado por `window.location.href` en `card.html:23`), `logout` (`views.py:42-44`).
+- **Descripción:** el middleware CSRF de Django solo protege métodos "unsafe" (POST/PUT/DELETE). Estas tres vistas cambian estado en GET, por lo que **no** están protegidas contra CSRF. `close_auction` sí verifica propiedad (`request.user == listing.user`, `views.py:180` — correcto contra IDOR), pero el cambio de estado sigue siendo forzable.
+- **Escenario de fallo:** una página maliciosa incrusta `<img src="https://sitio/listing/42/close">`; si la víctima (dueña del listing) está autenticada, la subasta se cierra sin su intención. Lo mismo aplica a `logout` y a eliminar de la watchlist.
+- **Recomendación:** requerir POST (`@require_POST`) y `{% csrf_token %}` en formularios; convertir los enlaces GET de `card.html:23` y las acciones de admin (`listings.html:166`, `listing_detail.html:114`) en formularios POST.
+
+### SEC-008 — `SECRET_KEY` con fallback inseguro
+
+- **Ubicación:** `commerce/settings.py:14`.
+- **Descripción:** `SECRET_KEY = os.getenv("SECRET_KEY", "a-default-secret-key-for-testing-only")`. Si la variable de entorno no está definida en producción, se usa silenciosamente un valor conocido, comprometiendo firmas de sesión, tokens CSRF y `PasswordResetTokenGenerator`.
+- **Escenario de fallo:** un despliegue sin `SECRET_KEY` configurada arranca sin error usando la clave pública del repositorio.
+- **Recomendación:** exigir la variable en producción: `SECRET_KEY = os.environ["SECRET_KEY"]` cuando `not DEBUG` (dejar el fallback solo para dev/tests). `docker-compose.yml` ya inyecta un valor de desarrollo.
+
+### SEC-009 — `|safe` con datos de BD dentro de `<script>`
+
+- **Ubicación:** `auctions/templates/auctions/admin/analytics.html:242,275,328`, `reports.html:340`, y los divs Plotly de `dashboard.html:130,142,157`.
+- **Descripción:** valores derivados de la BD (`market_trends`, `time_analysis`, `bid_analysis`) se interpolan con `|safe` como literales JavaScript. Al ser `repr()`/estructuras Python, no son JSON válido ni están escapados; cualquier string influido por el usuario (p. ej. una categoría o título usados como label) queda sin escapar dentro del `<script>`.
+- **Escenario de fallo:** un título/categoría de listing con `</script><script>...` que llegue a un label de gráfico produce ejecución de JS en el navegador del admin.
+- **Recomendación:** usar `{{ data|json_script:"id-datos" }}` y leer el JSON desde JS con `JSON.parse(document.getElementById(...).textContent)`, en lugar de `|safe`.
+
+### SEC-010 — Configuración de proxy/HTTPS incompleta
+
+- **Ubicación:** `commerce/settings.py:118-128`.
+- **Descripción:** el bloque `if not DEBUG` activa HSTS y cookies seguras, pero faltan `SECURE_SSL_REDIRECT` (forzar HTTPS), `SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")` (detrás de Heroku/nginx Django no detecta HTTPS y puede caer en bucles de redirección o cookies inseguras) y `CSRF_TRUSTED_ORIGINS` (requerido en Django 4+ para POST HTTPS con dominios personalizados).
+- **Escenario de fallo:** con `SESSION_COOKIE_SECURE=True` pero sin `SECURE_PROXY_SSL_HEADER`, Django ve la petición como HTTP y puede no emitir la cookie de sesión; los POST desde un dominio personalizado fallan con "CSRF verification failed".
+- **Recomendación:** añadir los tres settings dentro del bloque `if not DEBUG`, tomando `CSRF_TRUSTED_ORIGINS` de una variable de entorno.
+
+## Evidencia
+
+`bandit -r auctions/ commerce/ -ll` — sin hallazgos en código de aplicación (los 13 avisos Low son `B105/B106` en `auctions/tests/` legacy, contraseñas de prueba):
+
+```text
+Test results:
+	No issues identified.
+
+Run metrics:
+	Total issues (by severity):
+		Undefined: 0
+		Low: 13   (todos en auctions/tests/*, hardcoded test passwords)
+		Medium: 0
+		High: 0
+Total lines of code: 2587
+```
+
+`safety check -r requirements.txt` — sin vulnerabilidades conocidas, pero advierte que **todas las dependencias están sin fijar** (rangos `>=`), por lo que safety no analiza versiones flotantes (ver [code-quality.md](code-quality.md), CODE-007):
+
+```text
+Found and scanned 10 packages
+0 vulnerabilities reported
+35 vulnerabilities ignored   (paquetes sin pin: django, gunicorn, psycopg2-binary, ...)
+```
+
+## Referencias
+
+- La condición de carrera (SEC-001) y la falta de validación (SEC-002) se complementan con las constraints de BD propuestas en [code-quality.md](code-quality.md) (CODE-005).
+- El vector de `<img src>` con URL de usuario (SEC-013) también aparece como problema de UX de imágenes rotas en [ui-ux.md](ui-ux.md) (UX-006).
+- La ausencia de tests de concurrencia y de headers de seguridad se detalla en [testing-and-ci.md](testing-and-ci.md) (TEST-001, TEST-005).

--- a/docs/audits/testing-and-ci.md
+++ b/docs/audits/testing-and-ci.md
@@ -1,0 +1,86 @@
+# Auditoría de Tests y CI/CD — Sitio de Subastas
+
+> **Fecha:** 2026-07-02 · **Commit:** `784f51a` · **Rama:** `develop`
+> **Método:** inventario de la suite, ejecución de `pytest --cov`, revisión de `pyproject.toml` y los workflows de `.github/`. Ver metodología en [README.md](README.md).
+
+## Resumen
+
+Se identificaron **8 hallazgos**. La suite activa está sana (85 tests pasan, 81 % de cobertura sobre `auctions/`), pero la configuración de cobertura **excluye** los módulos más frágiles (analítica, admin), existe una suite legacy duplicada que no se ejecuta, y faltan tests para las clases de bug más peligrosas: concurrencia de pujas y cabeceras de seguridad. En CI, `safety` no bloquea y no hay comprobaciones de accesibilidad, rendimiento ni escaneo de contenedores.
+
+| Severidad | Cantidad |
+|-----------|----------|
+| Crítico   | 0 |
+| Alto      | 3 |
+| Medio     | 3 |
+| Bajo      | 2 |
+
+## Hallazgos
+
+| ID | Severidad | Ubicación | Resumen | Esfuerzo | PR sugerido |
+|----|-----------|-----------|---------|----------|-------------|
+| TEST-001 | Alto | `tests/unit/test_models.py` | Sin test de concurrencia para `place_bid` (la condición de carrera SEC-001 no está cubierta) | M | `chore/deps-and-tests` |
+| TEST-002 | Alto | `pyproject.toml` `[tool.coverage.run] omit` | Cobertura omite `admin_views.py`, `analytics.py`, `data_utils.py`: los módulos con los bugs críticos CODE-001/002 no se testean | M | `chore/deps-and-tests` |
+| TEST-003 | Alto | `auctions/tests/` | Suite legacy duplicada fuera de `testpaths=["tests"]`: no se ejecuta, confunde y arrastra avisos de bandit | S | `chore/deps-and-tests` |
+| TEST-004 | Medio | `tests/e2e/` | Directorio e2e vacío (solo `__init__.py`); `fixtures/axe.min.js` sin trackear y propiedad de root; cero tests Playwright pese a estar provisionado en CI | M | `chore/deps-and-tests` |
+| TEST-005 | Medio | `tests/` (global) | Sin tests de cabeceras de seguridad (HSTS, X-Frame-Options, cookies seguras) | S | `chore/deps-and-tests` |
+| TEST-006 | Medio | `tests/unit/test_theme_colors.py` | Los tests de contraste no cubren los 11 pares que fallan (badges/botones Bootstrap); solo validan `variables.css` | S | `fix/a11y-css-variables` |
+| TEST-007 | Bajo | `tests/integration/` | Sin `assertNumQueries` para detectar regresiones N+1 (PERF-004/008) | S | `chore/deps-and-tests` |
+| TEST-008 | Bajo | `.github/workflows/pr-validate.yml` | `safety` corre con `continue-on-error: true` (no bloquea); sin a11y/perf/escaneo de contenedor/CodeQL en CI | M | `chore/deps-and-tests` |
+
+## Detalle de hallazgos Alto
+
+### TEST-001 — Sin cobertura de concurrencia
+
+- **Ubicación:** `tests/unit/test_models.py` (cubre `place_bid` en el camino feliz, pero no la carrera).
+- **Descripción:** el bug de mayor severidad de la auditoría (SEC-001, condición de carrera con dinero) no tiene test que lo reproduzca ni que verifique la corrección con transacción/`select_for_update`.
+- **Recomendación:** añadir un test que simule pujas concurrentes (p. ej. con `TransactionTestCase` y hilos, o verificando que dos `place_bid` con el mismo `current_bid` de partida no ambos tengan éxito). Debe acompañar al fix de SEC-001.
+
+### TEST-002 — Cobertura ciega en los módulos frágiles
+
+- **Ubicación:** `pyproject.toml`, sección `[tool.coverage.run] omit` (excluye `admin_views.py`, `analytics.py`, `data_utils.py`, `admin_config.py`, `management/commands/generate_reports.py`).
+- **Descripción:** el 81 % de cobertura reportado se calcula **excluyendo** justamente los módulos donde viven los bugs críticos CODE-001 (analytics rota en Postgres) y CODE-002 (imports ausentes). Esos módulos suman ~37 KB de código sin ninguna prueba.
+- **Recomendación:** retirar `analytics.py`/`data_utils.py`/`admin_views.py` de la lista `omit` y añadir tests que ejerciten sus rutas contra una BD PostgreSQL (el workflow `_reusable-tests.yml` ya levanta un servicio Postgres 16). Esto habría detectado CODE-001 automáticamente.
+
+### TEST-003 — Suite legacy duplicada
+
+- **Ubicación:** `auctions/tests/` (`factories.py`, `test_forms.py`, `test_integration.py`, `test_models.py`, `test_templates.py`, `test_views.py`).
+- **Descripción:** `testpaths = ["tests"]` en `pyproject.toml` solo recoge la suite de nivel superior. La suite dentro de `auctions/tests/` está trackeada en git pero **no se ejecuta** en local ni en CI, y es la fuente de los 13 avisos Low de bandit (contraseñas de prueba hardcodeadas). Es un layout Django antiguo abandonado.
+- **Recomendación:** decidir cuál es la suite canónica (`tests/` según `CLAUDE.md`) y eliminar `auctions/tests/`, o migrar lo que aún aporte. Documentar la convención en la guía de tests.
+
+## Estado de la suite (contexto)
+
+- **85 tests** pasan; **81 %** de cobertura sobre `auctions/` (umbral configurado: **70 %**).
+- Factories con `factory-boy` en `tests/conftest.py`: `UserFactory`, `ListingFactory`, `BidFactory`, `CommentFactory`, `WatchlistFactory`.
+- Módulos con baja cobertura visible: `error_views.py` (32 %), `middleware.py` (49 %), `templatetags/auctions_filters.py` (59 %).
+
+## Estado de CI/CD (contexto)
+
+- `pr-validate.yml`: lint + tests + `bandit -r auctions/ -ll` + `safety check` (no bloqueante) + publicación de reporte en gh-pages.
+- `_reusable-tests.yml`: levanta Postgres 16, instala `requirements-dev.txt`, `playwright install chromium`, migra y corre pytest.
+- `cd-develop.yml`: **deshabilitado** (`workflow_dispatch`), pendiente del stack Oracle VM/k3s.
+- `cd-production.yml`: build + push GHCR + deploy Heroku (container stack).
+- **Sin** comprobaciones de accesibilidad (axe/pa11y/Lighthouse), rendimiento, escaneo de imágenes (Trivy/Grype) ni SAST más allá de bandit.
+
+## Evidencia
+
+`pytest --cov=auctions --cov-report=term-missing -q` (resumen):
+
+```text
+auctions/error_views.py                        63     43    32%
+auctions/middleware.py                         35     18    49%
+auctions/models.py                             52      1    98%
+auctions/forms.py                              59      2    97%
+auctions/views.py                             146      5    97%
+auctions/templatetags/auctions_filters.py      17      7    59%
+-------------------------------------------------------------------------
+TOTAL                                         417     78    81%
+85 passed, 35 warnings in 23.00s
+```
+
+Nota: `admin_views.py`, `analytics.py` y `data_utils.py` no aparecen en el informe porque están en la lista `omit` (TEST-002).
+
+## Referencias
+
+- TEST-001 acompaña a la corrección de la condición de carrera en [security.md](security.md) (SEC-001).
+- TEST-002 cubre los módulos de los bugs de [code-quality.md](code-quality.md) (CODE-001, CODE-002).
+- TEST-006 amplía los tests de contraste de [accessibility.md](accessibility.md) (A11Y-002/003/004).

--- a/docs/audits/ui-ux.md
+++ b/docs/audits/ui-ux.md
@@ -1,0 +1,61 @@
+# Auditoría de UI/UX — Sitio de Subastas
+
+> **Fecha:** 2026-07-02 · **Commit:** `784f51a` · **Rama:** `develop`
+> **Método:** análisis estático de plantillas, CSS y JS. Sin auditoría en vivo. Ver metodología en [README.md](README.md).
+
+## Resumen
+
+Se identificaron **12 hallazgos** de UI/UX. Varios son "UI muerta": controles renderizados que no hacen nada porque la vista no pasa los datos o el `<form>` no tiene `action`/`name`. También hay inconsistencias sistemáticas (dos versiones de Bootstrap, seis formatos de fecha) y una acción destructiva sin confirmación. El aspecto de contraste/accesibilidad se trata aparte en [accessibility.md](accessibility.md).
+
+| Severidad | Cantidad |
+|-----------|----------|
+| Crítico   | 0 |
+| Alto      | 3 |
+| Medio     | 5 |
+| Bajo      | 4 |
+
+## Hallazgos
+
+| ID | Severidad | Ubicación | Resumen | Esfuerzo | PR sugerido |
+|----|-----------|-----------|---------|----------|-------------|
+| UX-001 | Alto | `index.html:29-60`, `auctions/views.py:20` | Formulario de filtros sin `name`/`action`; la vista `index` no pasa `categories`: el filtro no funciona | M | `chore/frontend-consistency` |
+| UX-002 | Alto | `index.html:110` | `{% include "auctions/components/mini_card.html" %}` a un archivo inexistente: 500 si `recently_viewed_items` se poblara | S | `chore/frontend-consistency` |
+| UX-003 | Alto | `auction.html:144-149` | Cierre de subasta (acción destructiva) sin diálogo de confirmación | S | `chore/frontend-consistency` |
+| UX-004 | Medio | `layout.html:28`, `admin/base.html:19` | Bootstrap 5.3.3 (público) vs 5.3.0 (admin); Font Awesome 6.0.0 vs 6.4.0 | S | `chore/frontend-consistency` |
+| UX-005 | Medio | `dashboard.html:191`, `listings.html:123`, `listing_detail.html:76` | Moneda sin `floatformat:2` en admin: decimales variables (`$1200.5` vs `$1200.50`) | S | `chore/frontend-consistency` |
+| UX-006 | Medio | `card.html:34`, `auction.html:27`, `admin/listings.html:98` | Imágenes de URL sin `onerror` fallback: URL rota muestra el glifo de imagen partida | S | `chore/frontend-consistency` |
+| UX-007 | Medio | `admin/base.html:114` | Mensajes admin usan `alert-{{ message.tags }}`: un `error` de Django genera `alert-error`, que no es clase Bootstrap → alerta sin estilo | S | `chore/frontend-consistency` |
+| UX-008 | Medio | `card.html:5,10,15,76`, `auction.html:54,70,106,178` | Plantillas referencian atributos inexistentes (`bids_count`, `is_new`, `is_premium`, `views`, `is_ending_soon`): renderizan vacío (UI muerta) | S | `chore/frontend-consistency` |
+| UX-009 | Bajo | `card.html:88` vs `auction.html:174,234` vs admin | Seis formatos de fecha distintos (`M d, Y` / `F j, Y` / `j M Y, H:i` / `d/m/Y H:i` / …) | S | `chore/frontend-consistency` |
+| UX-010 | Bajo | `footer.html:14-24,89-90` | Enlaces de footer (redes, legales) son anclas `#` muertas | S | `chore/frontend-consistency` |
+| UX-011 | Bajo | `layout.js:79,100,114,285` | `console.log` de depuración en JS de producción | S | `chore/frontend-consistency` |
+| UX-012 | Bajo | `login.html:22-27`, `register.html:24-32` | Login/register usan una variable `message` genérica en vez del framework de mensajes: no muestran errores de validación por campo | M | `chore/frontend-consistency` |
+
+## Detalle de hallazgos Alto
+
+### UX-001 — Formulario de filtros que no filtra
+
+- **Ubicación:** `index.html:29-60` (los `<select>` `#categoryFilter` y `#sortBy`), vista en `auctions/views.py:15-20`.
+- **Descripción:** el `<form>` no tiene `action` ni `method`, y los `<select>` no tienen `name`, así que al enviarlo no viaja nada. Además la vista `index` solo pasa `{"listings": ...}` — no pasa `categories`, por lo que el desplegable de categorías siempre está vacío. Es un control visible que aparenta funcionalidad inexistente.
+- **Escenario de fallo:** el usuario selecciona una categoría y pulsa "Apply Filters"; la página se recarga sin filtrar (o no hace nada).
+- **Recomendación:** o bien conectar el formulario a la vista `categories` existente (`views.py:194-219`, que sí filtra y ya calcula las categorías), pasándole los datos y `name`/`action` correctos; o bien retirar el control de `index.html` hasta implementarlo.
+
+### UX-002 — Include a plantilla inexistente
+
+- **Ubicación:** `index.html:110` (`{% include "auctions/components/mini_card.html" %}`).
+- **Descripción:** el archivo `mini_card.html` no existe en el árbol de plantillas. Hoy no explota solo porque la vista nunca pasa `recently_viewed_items`, así que el bloque no se ejecuta; es una bomba latente.
+- **Escenario de fallo:** si alguien puebla `recently_viewed_items` en el contexto, la página lanza `TemplateDoesNotExist` (500).
+- **Recomendación:** crear el componente o eliminar el bloque "Recently Viewed" de `index.html` mientras no exista la funcionalidad.
+
+### UX-003 — Cierre de subasta sin confirmación
+
+- **Ubicación:** `auction.html:144-149`.
+- **Descripción:** la acción de cerrar subasta (irreversible: fija ganador y desactiva) es un botón POST sin `confirm()`. En cambio, acciones menos críticas sí confirman (eliminar de watchlist en `card.html:23`; toggle admin en `listings.html:240-248`).
+- **Escenario de fallo:** un clic accidental cierra la subasta sin posibilidad de deshacer desde la UI.
+- **Recomendación:** añadir confirmación (diálogo nativo o modal Bootstrap) antes del submit. Combinar con el cambio a POST + CSRF de [security.md](security.md) (SEC-005).
+
+## Referencias
+
+- El contraste de badges/botones y los problemas de accesibilidad (foco, h1, skip-link) están en [accessibility.md](accessibility.md).
+- UX-003 se solapa con SEC-005 (cierre de subasta) en [security.md](security.md).
+- UX-006 (imágenes de URL) también es un vector de contenido mixto en [security.md](security.md) (SEC-013).

--- a/docs/oracle-vm-stack.md
+++ b/docs/oracle-vm-stack.md
@@ -180,10 +180,13 @@ kubectl -n argocd get secret argocd-initial-admin-secret \
 
 **Conectar Argo CD con GitHub:**
 En la UI de Argo CD → Settings → Repositories → Connect Repo
-- URL: `https://github.com/sandovaldavid/auctions`
+- URL: `https://github.com/sandovaldavid/project-02-auctions`
 - Tipo: HTTPS con GitHub App Token o Personal Access Token
 
 **Crear Application para staging:**
+
+> Nota: el directorio `k8s/` (manifiestos Deployment/Service/IngressRoute) es estructura **planificada**; aún no existe en el repositorio. Crearlo es parte de habilitar el CD de staging (ver `cd-develop.yml`, hoy deshabilitado).
+
 ```yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -193,7 +196,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/sandovaldavid/auctions
+    repoURL: https://github.com/sandovaldavid/project-02-auctions
     targetRevision: develop
     path: k8s/staging
   destination:
@@ -238,7 +241,6 @@ docker run -d \
 # docker-compose.glitchtip.yml
 mkdir -p ~/glitchtip && cd ~/glitchtip
 cat > docker-compose.yml <<'EOF'
-version: "3"
 x-environment: &default-environment
   DATABASE_URL: postgres://glitchtip:glitchtip@postgres:5432/glitchtip
   SECRET_KEY: cambia-esto-por-algo-seguro
@@ -298,7 +300,6 @@ sentry_sdk.init(
 ```bash
 mkdir -p ~/monitoring && cd ~/monitoring
 cat > docker-compose.yml <<'EOF'
-version: "3"
 services:
   prometheus:
     image: prom/prometheus:latest


### PR DESCRIPTION
## Contexto

Revisión estática completa del proyecto (seguridad, calidad de código, accesibilidad/contraste, rendimiento, UI/UX y tests/CI) documentada en `docs/`, más actualización de la documentación existente. **Solo documentación** — sin cambios en el código de la aplicación; cada hallazgo lleva severidad y remediación para PRs futuros.

## Qué incluye

- **`docs/audits/`** — 6 informes por área + índice ejecutivo (`README.md`) con **70 hallazgos** (`archivo:línea`, severidad, esfuerzo, PR sugerido) y un roadmap de 10 PRs alineado a la estrategia de ramas de `CLAUDE.md`.
- **`docs/README.md`** — índice general de la documentación.
- **`docs/Docker.md`** — reescrito por completo (era el stub genérico de `docker init`): stack real (Dockerfile, Compose dev/prod con nginx+certbot, Heroku, GHCR).
- **`docs/oracle-vm-stack.md`** — retoques mínimos (URL del repo, `version: "3"` obsoleto, nota sobre `k8s/` planificado).
- **`README.md`** — sección de enlaces a docs y corrección `python manage.py test` → `pytest`.

## Distribución por severidad

| Crítico | Alto | Medio | Bajo | Total |
|:---:|:---:|:---:|:---:|:---:|
| 7 | 23 | 25 | 15 | **70** |

### Hallazgos críticos
1. Condición de carrera en `place_bid` (pujas concurrentes sin transacción)
2. `place_bid` acepta pujas por debajo del precio inicial
3. Analítica rota en PostgreSQL (`User` equivocado + SQL solo-SQLite)
4. `numpy`/`pandas` ausentes de `requirements.txt` → `ImportError` en producción
5. `register` omite los validadores de contraseña y lanza 500
6. `test_admin_dashboard` filtra conteos sin autenticación
7. 87 variables CSS rotas en el `components.css` cargado

## Evidencia

- `bandit`/`safety`/`ruff`/`black`/`mypy`/`pytest` (85 tests, 81% cobertura) ejecutados; salida real embebida en cada informe.
- Contraste WCAG calculado matemáticamente: 23 pares, **11 fallan AA** (reutiliza las fórmulas de `tests/unit/test_theme_colors.py`).

## Notas

- Merge sugerido: **Squash and merge** (rama `docs/*` → `develop`, según `CLAUDE.md`).