### PR TITLE
docs(docs): add task backlog and AGENTS.md, refresh CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,74 @@
+# AGENTS.md — Guía operativa para agentes
+
+Punto de entrada para agentes de IA que trabajan en este repositorio. Define **cómo trabajar** aquí; las convenciones detalladas (tablas de tipos/scopes de commit, estrategia de merge, workflows) están en [CLAUDE.md](CLAUDE.md) — este archivo remite a ellas, no las duplica.
+
+## Snapshot del proyecto
+
+Monolito Django 5.1 (sitio de subastas, SSR con Bootstrap 5.3). Una sola app `auctions/`; configuración en `commerce/`. BD SQLite en dev, PostgreSQL 16 en prod. Despliegue en Heroku (container stack); staging futuro en Oracle VM. Ver el stack completo y la arquitectura objetivo en [CLAUDE.md](CLAUDE.md).
+
+**Decisión de arquitectura:** se mantiene Django monolito. No migrar a otro framework ni a microservicios sin evidencia de necesidad de escala.
+
+## Setup rápido
+
+```bash
+# Dependencias
+pip install -r requirements.txt -r requirements-dev.txt
+
+# App + PostgreSQL con Docker
+docker compose up --build          # http://localhost:8000
+docker compose exec web python manage.py migrate
+
+# Tests
+pytest                             # con cobertura (mínimo 70%)
+```
+
+Variables de entorno: copiar `.env.example` a `.env`. Guía Docker: [docs/Docker.md](docs/Docker.md).
+
+## Reglas de trabajo
+
+1. **Conventional Commits obligatorio**, con **scope** siempre presente: `type(scope): descripción imperativa en minúsculas`. Tipos y scopes válidos: tablas en [CLAUDE.md](CLAUDE.md#commits--conventional-commits-obligatorio). Sin emojis, sin mayúsculas iniciales, sin punto final.
+2. **Ramas:** trabaja en `feature/*`, `fix/*`, `chore/*` o `refactor/*` partiendo de `develop`. **Nunca** commitees directo a `main` ni a `develop`. Merge a `develop` con **"Squash and merge"**. Reglas completas: [CLAUDE.md](CLAUDE.md#ramas).
+3. **Quality gates antes de abrir un PR** (todos deben pasar):
+   ```bash
+   ruff check .
+   black --check .
+   mypy auctions/
+   bandit -r auctions/ -ll
+   pytest                 # cobertura ≥ 70%
+   ```
+   El workflow `pr-validate` corre estos mismos checks; no dependas de él, pásalos localmente.
+4. **Tests:** todo código nuevo en `auctions/` requiere test. Usa las factories de `tests/conftest.py` (`UserFactory`, `ListingFactory`, …); no crees objetos a mano. La suite canónica es `tests/` (no `auctions/tests/`, que es legacy).
+5. **Estilo de código:** líneas ≤ 88 (Black); sin `print()` en código de producción; los comentarios explican el PORQUÉ, no el QUÉ.
+
+## Mapa del código
+
+| Ruta | Contenido |
+|------|-----------|
+| `auctions/models.py` | `User`, `Listing`, `Bid`, `Comment`, `Watchlist` (lógica de pujas en `Listing.place_bid`) |
+| `auctions/views.py` | 12 vistas SSR públicas |
+| `auctions/forms.py` | `ListingForm`, `BidForm`, `CommentForm` |
+| `auctions/admin_views.py` | Panel admin/BI (solo superusuario) |
+| `auctions/analytics.py`, `data_utils.py` | Reportes y series (dependen de pandas/plotly) |
+| `auctions/middleware.py`, `error_views.py` | Middleware y páginas de error |
+| `auctions/templates/auctions/` | Plantillas (base pública `layout.html`; admin en `admin/`) |
+| `auctions/static/css/` | `variables.css` es la fuente de verdad de color |
+| `commerce/` | `settings.py`, `urls.py`, `wsgi.py`, `asgi.py` |
+| `tests/` | Suite pytest (unit/integration/e2e) |
+
+## Backlog y hallazgos conocidos
+
+Antes de proponer trabajo, consulta:
+
+- **[docs/tasks/](docs/tasks/README.md)** — tablero de tareas priorizadas; una ficha por rama con checklist, instrucciones, verificación y mensajes de commit sugeridos. Empieza por la prioridad más alta que esté `Pendiente`.
+- **[docs/audits/](docs/audits/README.md)** — auditoría completa (70 hallazgos con `archivo:línea`, severidad y remediación).
+
+Si trabajas un hallazgo, usa la rama indicada en su ficha y marca su checkbox al terminar.
+
+## Qué NO hacer
+
+- No migrar de Django a otro stack ni introducir microservicios.
+- No reescribir ni renombrar migraciones históricas de `auctions/migrations/`.
+- No exponer secretos: `SECRET_KEY` y credenciales vienen de variables de entorno, nunca hardcodeadas.
+- No commitear directo a `main`/`develop` ni saltarte los quality gates.
+- No romper la convención de Conventional Commits (scope obligatorio).
+- No añadir dependencias de runtime a `requirements-dev.txt` (los módulos de prod solo pueden importar lo que está en `requirements.txt`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Guía de referencia para Claude Code y colaboradores. Define la arquitectura obj
 
 | Capa | Tecnología |
 |------|-----------|
-| Backend | Django 5.1+ / Python 3.10 |
+| Backend | Django 5.1+ / Python 3.10 (target de tooling; imagen runtime `python:3.12-slim`) |
 | Base de datos dev | SQLite (local) |
 | Base de datos prod | PostgreSQL 16 |
 | Frontend | Django Templates + Bootstrap 5.3 |
@@ -25,10 +25,15 @@ Guía de referencia para Claude Code y colaboradores. Define la arquitectura obj
 ```
 Django Monolith (actual)
   └── auctions/          ← única app Django
-       ├── models.py     ← User, Listing, Bid, Comment, Watchlist
-       ├── views.py      ← 11 vistas SSR
-       ├── forms.py      ← ListingForm, BidForm, CommentForm
-       └── templates/    ← Bootstrap 5.3
+       ├── models.py       ← User, Listing, Bid, Comment, Watchlist
+       ├── views.py        ← 12 vistas SSR públicas
+       ├── forms.py        ← ListingForm, BidForm, CommentForm
+       ├── admin_views.py  ← panel admin/BI (superuser) — 13 vistas
+       ├── analytics.py    ← reportes y series (usa pandas/plotly)
+       ├── data_utils.py   ← generación de reportes
+       ├── middleware.py   ← Custom404Middleware, error handlers
+       ├── error_views.py  ← páginas de error 400/403/404/500
+       └── templates/      ← Bootstrap 5.3
 
 Evolución planificada (en fases):
   Fase 2 → djangorestframework: API endpoints para Listing/Bid/Watchlist
@@ -45,7 +50,7 @@ Evolución planificada (en fases):
 | Entorno | Plataforma | Trigger |
 |---------|-----------|---------|
 | Local | `docker compose up` | Manual |
-| Staging | Oracle VM (k3s + Argo CD) | Push a `develop` |
+| Staging | Oracle VM (k3s + Argo CD) | Pendiente — `cd-develop` está deshabilitado (`workflow_dispatch`) hasta que el stack Oracle VM esté listo |
 | Producción | Heroku (Docker stack) | Push a `main` via GitHub Actions |
 | Producción futura | Oracle VM | Cuando se agoten créditos Heroku |
 
@@ -126,7 +131,7 @@ ci(ci): add path filter to devcontainer workflow
 | `docker` | Dockerfile, docker-compose.yml, docker-compose.prod.yml, nginx/ |
 | `deps` | requirements.txt, requirements-dev.txt, pyproject.toml |
 | `devcontainer` | .devcontainer/ |
-| `docs` | docs/, README.md, CLAUDE.md |
+| `docs` | docs/ (incl. docs/audits/, docs/tasks/), README.md, CLAUDE.md, AGENTS.md |
 | `infra` | Oracle VM, k3s, Argo CD, Heroku, scripts de infraestructura |
 | `gh-pages` | Rama gh-pages, reportes de tests, index.html |
 | `release` | release-please-config.json, .release-please-manifest.json, CHANGELOG |
@@ -175,18 +180,21 @@ Los hooks en `.pre-commit-config.yaml` corren automáticamente en cada commit: r
 ### Stack
 
 ```
-tests/
+tests/                   # suite canónica (testpaths = ["tests"])
 ├── conftest.py          # Factories (factory-boy) + fixtures pytest
 ├── unit/
-│   ├── test_models.py   # Listing.place_bid(), Watchlist, Bid, Comment
-│   └── test_forms.py    # Validación de ListingForm, BidForm, CommentForm
+│   ├── test_models.py       # Listing.place_bid(), Watchlist, Bid, Comment
+│   ├── test_forms.py        # Validación de ListingForm, BidForm, CommentForm
+│   └── test_theme_colors.py # Contraste WCAG 2.1 (estático) de variables.css
 ├── integration/
 │   ├── test_views_auth.py
 │   ├── test_views_auction.py
 │   ├── test_views_watchlist.py
 │   └── test_views_categories.py
-└── e2e/                 # Playwright — flujos completos en browser
+└── e2e/                 # Provisionado para Playwright + axe-core, aún SIN tests
 ```
+
+> `auctions/tests/` es una suite legacy fuera de `testpaths` (no se ejecuta) — ver [docs/audits/testing-and-ci.md](docs/audits/testing-and-ci.md) (TEST-003).
 
 ### Correr tests
 
@@ -208,6 +216,14 @@ pytest --cov=auctions --cov-report=term-missing --no-header -q
 - Cobertura mínima: **70%** (`--cov-fail-under=70` en pyproject.toml)
 - Todo código nuevo en `auctions/` debe tener test correspondiente
 - Usar factories (`UserFactory`, `ListingFactory`, etc.) — no crear objetos directamente
+
+---
+
+## Backlog y auditoría
+
+- **Hallazgos:** [docs/audits/](docs/audits/README.md) — auditoría completa (seguridad, rendimiento, accesibilidad, UI/UX, tests).
+- **Tareas priorizadas:** [docs/tasks/](docs/tasks/README.md) — tablero por prioridad, una ficha por rama con checklist e instrucciones.
+- **Guía operativa para agentes:** [AGENTS.md](AGENTS.md).
 
 ---
 
@@ -253,7 +269,7 @@ cp .env.example .env
 | Workflow | Trigger | Hace qué |
 |---------|---------|---------|
 | `pr-validate` | PR → develop o main | Lint + tests + security scan + publica reporte en gh-pages |
-| `cd-develop` | Push a develop | Tests + build Docker + push GHCR + actualiza reporte develop |
+| `cd-develop` | Manual (`workflow_dispatch`) — deshabilitado hasta Oracle VM | Tests + build Docker + push GHCR + actualiza reporte develop |
 | `cd-production` | Push a main | Tests + build Docker + deploy Heroku + actualiza reporte main |
 | `release-please` | Push a main | Crea PR de release con CHANGELOG automático |
 | `devcontainer` | Push (paths: `.devcontainer/**`) | Build + push imagen a GHCR |

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -1,0 +1,64 @@
+# Tablero de tareas — Sitio de Subastas
+
+Backlog accionable derivado de la [auditoría del proyecto](../audits/README.md) (70 hallazgos). Cada fila es una rama de trabajo = un PR. Trabaja de arriba hacia abajo por prioridad.
+
+## Cómo trabajar una tarea
+
+1. Elige la ficha con la prioridad más alta que esté `Pendiente`.
+2. Crea la rama desde `develop` (comandos en cada ficha):
+   ```bash
+   git checkout develop && git pull
+   git checkout -b <rama-de-la-ficha>
+   ```
+3. Resuelve los hallazgos marcando el checklist de la ficha; sigue sus instrucciones y añade los tests indicados.
+4. Pasa los **quality gates** antes de abrir el PR:
+   ```bash
+   ruff check .
+   black --check .
+   mypy auctions/
+   bandit -r auctions/ -ll
+   pytest            # cobertura mínima 70%
+   ```
+5. Commits con [Conventional Commits](../../CLAUDE.md#commits--conventional-commits-obligatorio) (scope obligatorio).
+6. Abre PR a `develop` y mergea con **"Squash and merge"** (ver [reglas de ramas](../../CLAUDE.md#ramas)).
+7. Actualiza el **Estado** de la fila en este tablero.
+
+Convenciones completas: [CLAUDE.md](../../CLAUDE.md) · Guía operativa para agentes: [AGENTS.md](../../AGENTS.md).
+
+## Leyenda de estado
+
+`Pendiente` · `En progreso` · `Hecho`
+
+## Prioridad 1 — Crítico
+
+| Rama | Área | Hallazgos | Esfuerzo | Estado | Ficha |
+|------|------|-----------|:--------:|--------|-------|
+| `fix/security-critical` | Seguridad | SEC-001,002,003,005,006,007,008,011 · CODE-004 | M | Pendiente | [p1-fix-security-critical.md](p1-fix-security-critical.md) |
+| `fix/analytics-postgres` | Correctitud | CODE-001, CODE-002 | L | Pendiente | [p1-fix-analytics-postgres.md](p1-fix-analytics-postgres.md) |
+
+## Prioridad 2 — Alto
+
+| Rama | Área | Hallazgos | Esfuerzo | Estado | Ficha |
+|------|------|-----------|:--------:|--------|-------|
+| `fix/admin-routing` | Seguridad | SEC-004 | S | Pendiente | [p2-fix-admin-routing.md](p2-fix-admin-routing.md) |
+| `fix/xss-templates` | Seguridad | SEC-009, SEC-013, SEC-014 | M | Pendiente | [p2-fix-xss-templates.md](p2-fix-xss-templates.md) |
+| `fix/a11y-css-variables` | Accesibilidad | A11Y-001..007, A11Y-010, TEST-006 | L | Pendiente | [p2-fix-a11y-css-variables.md](p2-fix-a11y-css-variables.md) |
+
+## Prioridad 3 — Medio
+
+| Rama | Área | Hallazgos | Esfuerzo | Estado | Ficha |
+|------|------|-----------|:--------:|--------|-------|
+| `chore/settings-hardening` | Seguridad | SEC-010,012,015,016,017 | M | Pendiente | [p3-chore-settings-hardening.md](p3-chore-settings-hardening.md) |
+| `refactor/model-constraints` | Modelos | CODE-003,005,006 · PERF-006 | M | Pendiente | [p3-refactor-model-constraints.md](p3-refactor-model-constraints.md) |
+| `refactor/query-performance` | Rendimiento | PERF-001..005,007,008 | M | Pendiente | [p3-refactor-query-performance.md](p3-refactor-query-performance.md) |
+
+## Prioridad 4 — Bajo
+
+| Rama | Área | Hallazgos | Esfuerzo | Estado | Ficha |
+|------|------|-----------|:--------:|--------|-------|
+| `chore/frontend-consistency` | UI/UX | UX-001..012 · A11Y-009,011..014 · SEC-018 | M | Pendiente | [p4-chore-frontend-consistency.md](p4-chore-frontend-consistency.md) |
+| `chore/deps-and-tests` | Tooling/Tests | CODE-007..010 · TEST-001..005,007,008 | M | Pendiente | [p4-chore-deps-and-tests.md](p4-chore-deps-and-tests.md) |
+
+## Orden recomendado
+
+Prioridad 1 primero (seguridad crítica y rotura en producción). Dentro de P2, `fix/admin-routing` es el más rápido (un solo hallazgo). `refactor/model-constraints` conviene antes que `refactor/query-performance` porque los índices de PERF-006 viven en la misma migración de constraints. `chore/deps-and-tests` puede ir en paralelo en cualquier momento (no toca código de la app salvo tests).

--- a/docs/tasks/p1-fix-analytics-postgres.md
+++ b/docs/tasks/p1-fix-analytics-postgres.md
@@ -1,0 +1,71 @@
+# Tarea: `fix/analytics-postgres` — Analítica funcional en PostgreSQL
+
+> **Prioridad:** 1 (Crítico) · **Rama base:** `develop` · **Merge:** Squash and merge · **Estado:** Pendiente
+> **Detalle de hallazgos:** [../audits/code-quality.md](../audits/code-quality.md)
+
+## Objetivo
+
+La cadena de analítica está rota en producción: importa el modelo `User` equivocado y usa SQL exclusivo de SQLite (falla en la BD PostgreSQL de producción), y varios módulos importan `numpy`/`pandas` que no están en `requirements.txt` (fallo de importación en la imagen de producción). Es prioridad 1 porque son roturas garantizadas fuera de dev, hoy enmascaradas por un `try/except` amplio.
+
+## Rama
+
+```bash
+git checkout develop && git pull
+git checkout -b fix/analytics-postgres
+```
+
+## Hallazgos a resolver
+
+- [ ] **CODE-001** — `analytics.py` importa `django.contrib.auth.models.User` + `.extra()` solo-SQLite (`auctions/analytics.py:19,84,93,102,283,296`)
+- [ ] **CODE-002** — `numpy`/`pandas` ausentes de `requirements.txt` (`auctions/data_utils.py:8`, `management/commands/generate_reports.py:86`)
+
+## Instrucciones / recomendaciones
+
+1. **CODE-001 (User swapped).** Cambiar `from django.contrib.auth.models import User` por `get_user_model()`:
+
+   ```python
+   from django.contrib.auth import get_user_model
+   User = get_user_model()
+   ```
+
+2. **CODE-001 (SQL agnóstico).** Sustituir `.extra(select={...})` con `date(...)`/`strftime(...)` por funciones de BD portables:
+
+   ```python
+   from django.db.models.functions import TruncDate, TruncMonth
+   # ej.: .annotate(day=TruncDate("created")).values("day").annotate(n=Count("id"))
+   ```
+
+   `.extra()` está deprecado; `Trunc*` funciona igual en SQLite y PostgreSQL.
+
+3. **CODE-002 (dependencias).** Decidir si la analítica es funcionalidad de producción:
+   - **Si lo es:** mover `numpy`, `pandas`, `scikit-learn`, `plotly` de `requirements-dev.txt` a `requirements.txt`.
+   - **Si no:** proteger los imports (`try/except ImportError` con degradación, como ya hace `analytics.py:8-17`) y documentar que el panel BI requiere las deps de dev. Alinear con la decisión de arquitectura de [CLAUDE.md](../../CLAUDE.md) (analítica como fase futura).
+
+4. Quitar el `except Exception` amplio de `admin_dashboard` (`auctions/admin_views.py:58`) que hoy oculta estos fallos, o al menos loguearlos (ver `chore/settings-hardening`, SEC-012).
+
+## Tests requeridos
+
+- Retirar `analytics.py`/`data_utils.py`/`admin_views.py` de la lista `omit` de cobertura (**TEST-002**) y añadir tests que ejerciten `get_time_series_data`/`get_market_trends` **contra PostgreSQL** (el workflow `_reusable-tests.yml` ya levanta Postgres 16). Estos tests habrían detectado CODE-001.
+
+## Verificación
+
+```bash
+# Contra PostgreSQL (no SQLite) para reproducir el entorno de prod
+DATABASE_URL=postgres://... pytest tests/ -q -k analytics
+ruff check . && mypy auctions/
+```
+
+## Commits sugeridos
+
+```
+fix(auctions): use get_user_model in analytics
+fix(auctions): replace SQLite-only extra() with Trunc functions
+build(deps): move pandas and numpy to runtime requirements
+```
+
+## Criterios de done
+
+- [ ] Analítica funciona en PostgreSQL sin excepciones
+- [ ] Imports de `numpy`/`pandas` resueltos en la imagen de producción
+- [ ] Tests de analítica en la suite (fuera del `omit`); cobertura ≥ 70%
+- [ ] `pr-validate` en verde; PR a `develop`; fila actualizada en el [tablero](README.md)

--- a/docs/tasks/p1-fix-security-critical.md
+++ b/docs/tasks/p1-fix-security-critical.md
@@ -1,0 +1,90 @@
+# Tarea: `fix/security-critical` — Correcciones críticas de seguridad
+
+> **Prioridad:** 1 (Crítico) · **Rama base:** `develop` · **Merge:** Squash and merge · **Estado:** Pendiente
+> **Detalle de hallazgos:** [../audits/security.md](../audits/security.md) · [../audits/code-quality.md](../audits/code-quality.md)
+
+## Objetivo
+
+Cerrar los defectos de seguridad explotables de la app: la condición de carrera con dinero en las pujas, las mutaciones de estado vía GET (CSRF), el registro que evita los validadores de contraseña, la `SECRET_KEY` con fallback inseguro y los 500 por acceso crudo a `request.POST`. Es prioridad 1 porque son explotables por un tercero y algunos afectan a la integridad del dinero.
+
+## Rama
+
+```bash
+git checkout develop && git pull
+git checkout -b fix/security-critical
+```
+
+## Hallazgos a resolver
+
+- [ ] **SEC-001** — Condición de carrera en `place_bid` (`auctions/models.py:40-45`)
+- [ ] **SEC-002** — `place_bid` acepta pujas por debajo de `starting_bid`
+- [ ] **SEC-003** — `register` omite `AUTH_PASSWORD_VALIDATORS` (`auctions/views.py:47-72`)
+- [ ] **SEC-005** — `close_auction` cambia estado en GET (`auctions/views.py:176-191`)
+- [ ] **SEC-006** — `watchlist_remove` muta estado en GET (`auctions/views.py:166-173`)
+- [ ] **SEC-007** — `logout` acepta GET (`auctions/views.py:42-44`)
+- [ ] **SEC-008** — `SECRET_KEY` con fallback hardcodeado (`commerce/settings.py:14`)
+- [ ] **SEC-011** — `login`/`register` leen `request.POST["campo"]` sin `.get()` → 500
+- [ ] **CODE-004** — `.get()` desnudos en `watchlist`/`watchlist_remove` → 500
+
+## Instrucciones / recomendaciones
+
+Orden sugerido (de mayor a menor riesgo):
+
+1. **SEC-001 + SEC-002 (juntos).** Envolver la lectura-modificación-escritura de `place_bid` en `transaction.atomic()` con `select_for_update()`, y usar `floor = current_bid or starting_bid` como piso de validación:
+
+   ```python
+   from django.db import transaction
+
+   def place_bid(self, user, bid_value):
+       with transaction.atomic():
+           listing = Listing.objects.select_for_update().get(pk=self.pk)
+           floor = listing.current_bid or listing.starting_bid
+           if bid_value <= floor:
+               raise ValidationError("The bid must be higher than the current bid.")
+           listing.current_bid = bid_value
+           listing.save(update_fields=["current_bid"])
+           Bid.objects.create(user=user, listing=listing, amount=bid_value)
+   ```
+
+2. **SEC-003 + SEC-011 (registro).** Reemplazar el `request.POST` crudo por `UserCreationForm` (o un `ModelForm` propio) que ejecute `validate_password()` y valide el email. Esto elimina de golpe el bypass de validadores y los `KeyError`→500 de esa vista.
+
+3. **SEC-005/006/007 (GET→POST).** Decorar `close_auction`, `watchlist_remove` y `logout` con `@require_POST`; convertir los disparadores en el frontend a formularios POST con `{% csrf_token %}` (el enlace GET de `card.html:23` y las acciones admin). `close_auction` ya valida propiedad (`views.py:180`) — mantener esa comprobación.
+
+4. **SEC-008.** Exigir `SECRET_KEY` cuando `not DEBUG`: `os.environ["SECRET_KEY"]` en producción, dejando el fallback solo para dev/tests.
+
+5. **CODE-004 + SEC-011 restante.** Sustituir los `.get()` por `get_object_or_404` y `request.POST.get("campo")`.
+
+Gotcha: `@require_POST` en `logout` implica que cualquier enlace/botón de logout del template debe ser un `<form method="post">`.
+
+## Tests requeridos
+
+- Test de concurrencia para `place_bid` (**TEST-001**): dos pujas partiendo del mismo `current_bid` no pueden ambas tener éxito. Usar `TransactionTestCase`.
+- Test de que una primera puja por debajo de `starting_bid` es rechazada (SEC-002).
+- Test de que `register` rechaza contraseñas débiles (SEC-003).
+- Test de que GET a `close_auction`/`watchlist_remove`/`logout` no muta estado (405).
+
+## Verificación
+
+```bash
+pytest tests/unit/test_models.py tests/integration/ -q
+bandit -r auctions/ -ll
+ruff check . && black --check . && mypy auctions/
+```
+
+## Commits sugeridos
+
+```
+fix(auctions): guard place_bid with transaction and select_for_update
+fix(auctions): reject bids below starting price
+fix(auctions): validate registration with UserCreationForm
+fix(auctions): require POST for close_auction, watchlist_remove and logout
+fix(commerce): require SECRET_KEY in production
+fix(auctions): use get_object_or_404 and POST.get in views
+```
+
+## Criterios de done
+
+- [ ] Todos los checkboxes de hallazgos marcados
+- [ ] Tests nuevos verdes; cobertura ≥ 70%
+- [ ] `pr-validate` en verde
+- [ ] PR a `develop` con "Squash and merge"; fila actualizada en el [tablero](README.md)

--- a/docs/tasks/p2-fix-a11y-css-variables.md
+++ b/docs/tasks/p2-fix-a11y-css-variables.md
@@ -1,0 +1,86 @@
+# Tarea: `fix/a11y-css-variables` — Sistema de variables CSS y contraste WCAG
+
+> **Prioridad:** 2 (Alto) · **Rama base:** `develop` · **Merge:** Squash and merge · **Estado:** Pendiente
+> **Detalle de hallazgos:** [../audits/accessibility.md](../audits/accessibility.md) · [../audits/testing-and-ci.md](../audits/testing-and-ci.md)
+
+## Objetivo
+
+Reparar la accesibilidad de la capa visual: unificar el sistema de variables CSS roto (los colores intencionales no se pintan), corregir los 11 pares de color que fallan WCAG AA, restaurar el indicador de foco, añadir el skip-link y los `<h1>` ausentes. El orden importa: **primero** las variables CSS, porque cambian qué colores están realmente en pantalla.
+
+## Rama
+
+```bash
+git checkout develop && git pull
+git checkout -b fix/a11y-css-variables
+```
+
+## Hallazgos a resolver
+
+- [ ] **A11Y-001** — 87 `var()` indefinidas en el `components.css` cargado (colores correctos en `static/css/components/*.css` huérfanos)
+- [ ] **A11Y-002** — Badges `bg-warning`/`bg-info` con texto blanco (1.63:1 / 1.96:1)
+- [ ] **A11Y-003** — `text-warning`/`text-info` sobre blanco
+- [ ] **A11Y-004** — Botones outline con color semántico crudo (2.15–3.76:1)
+- [ ] **A11Y-005** — Skip-link con CSS+JS pero sin elemento en el DOM
+- [ ] **A11Y-006** — Sin `<h1>` en index/watchlist/login/register
+- [ ] **A11Y-007** — `.bids-count` (`#d97706` sobre `#eff6ff`, 2.93:1)
+- [ ] **A11Y-010** — Anillo de foco eliminado (`login.css:76-80`, `auction.css:201-205`)
+- [ ] **TEST-006** — Ampliar `tests/unit/test_theme_colors.py` a los pares que fallan
+
+## Instrucciones / recomendaciones
+
+1. **A11Y-001 primero.** Unificar en el sistema de `variables.css`. Dos caminos:
+   - **Recomendado:** enlazar los 4 archivos `static/css/components/{card,alert,footer,pagination}.css` (que ya usan las variables correctas y con contraste corregido) y retirar los bloques legacy equivalentes de `components.css`.
+   - Alternativa: reescribir `components.css` para usar los nombres de `variables.css` (`--primary-500` en vez de `--primary-color`, etc.).
+
+   Verifica que no queden `var(--*)` sin definir (ver comando abajo).
+
+2. **A11Y-002/003 (badges/utilidades).** Añadir `text-dark` a los badges `bg-warning`/`bg-info` (patrón ya correcto en `auction.html:64`). Para texto, usar las variantes oscurecidas `--*-text`/`--*-dark` de `variables.css`.
+
+3. **A11Y-004/007 (botones y contadores).** Usar `--*-dark`/`--*-text` para el texto en reposo; mantener el color vivo solo para el fondo en `:hover` (donde el texto es blanco y sí contrasta).
+
+4. **A11Y-005 (skip-link).** Añadir como primer elemento del `<body>` en `layout.html`:
+   ```html
+   <a href="#main-content" class="skip-link">Saltar al contenido</a>
+   ```
+   y `tabindex="-1"` en `<main id="main-content">`. El CSS (`layout.css:27-45`) y el JS (`layout.js:172-184`) ya existen.
+
+5. **A11Y-006 (`<h1>`).** Promover el encabezado principal de cada página a `<h1>` conservando las clases visuales `display-*`. Revisar el salto h1→h4 en `auction.html`.
+
+6. **A11Y-010 (foco).** Restaurar un indicador de foco visible (outline o box-shadow con contraste) en `login.css:76-80` y `auction.css:201-205`.
+
+## Tests requeridos
+
+- **TEST-006:** ampliar `tests/unit/test_theme_colors.py` para cubrir los 11 pares que fallan (badges/botones Bootstrap), reutilizando `contrast_ratio`. Los tests deben fallar con el estado actual y pasar tras el fix.
+
+## Verificación
+
+```bash
+pytest tests/unit/test_theme_colors.py -q
+# No deben quedar variables CSS indefinidas en components.css:
+python3 - <<'EOF'
+import re
+defined=set()
+for f in ["auctions/static/css/variables.css","auctions/static/css/components.css"]:
+    defined|=set(re.findall(r'(--[\w-]+)\s*:',open(f).read()))
+used=re.findall(r'var\((--[\w-]+)',open("auctions/static/css/components.css").read())
+undef=[u for u in used if u not in defined]
+print("indefinidas:",len(undef))
+EOF
+```
+
+## Commits sugeridos
+
+```
+fix(auctions): unify CSS variable system and drop legacy components.css
+fix(auctions): meet WCAG AA contrast for badges and outline buttons
+fix(auctions): add skip link and restore focus indicators
+fix(auctions): add missing h1 headings on public pages
+test(tests): extend contrast tests to Bootstrap badge and button pairs
+```
+
+## Criterios de done
+
+- [ ] Cero `var()` indefinidas en `components.css`
+- [ ] Los 11 pares de contraste pasan WCAG AA (verificado por test)
+- [ ] Skip-link funcional; foco visible; `<h1>` en todas las páginas públicas
+- [ ] `pr-validate` en verde; PR a `develop`; fila actualizada en el [tablero](README.md)

--- a/docs/tasks/p2-fix-admin-routing.md
+++ b/docs/tasks/p2-fix-admin-routing.md
@@ -1,0 +1,60 @@
+# Tarea: `fix/admin-routing` — Endpoint admin sin autenticación
+
+> **Prioridad:** 2 (Alto) · **Rama base:** `develop` · **Merge:** Squash and merge · **Estado:** Pendiente
+> **Detalle de hallazgos:** [../audits/security.md](../audits/security.md)
+
+## Objetivo
+
+Cerrar la fuga de datos de negocio a usuarios anónimos a través de `test_admin_dashboard`, una vista de prueba que quedó expuesta sin autenticación ni guard de `DEBUG`. Rápida de resolver (un solo hallazgo).
+
+## Rama
+
+```bash
+git checkout develop && git pull
+git checkout -b fix/admin-routing
+```
+
+## Hallazgos a resolver
+
+- [ ] **SEC-004** — `test_admin_dashboard` sin auth ni guard `DEBUG` (`auctions/admin_views.py:420`, ruta en `auctions/urls.py:47`)
+
+## Instrucciones / recomendaciones
+
+Opción recomendada: **eliminar** la vista `test_admin_dashboard` (`admin_views.py:420`) y su ruta `test/admin/` (`urls.py:47`), ya que es una vista de prueba que no debería existir en producción.
+
+Si se quiere conservar para desarrollo, protegerla con el mismo patrón que el resto del panel más un guard de `DEBUG`:
+
+```python
+from django.conf import settings
+from django.http import Http404
+from django.contrib.auth.decorators import user_passes_test
+
+@user_passes_test(is_superuser)
+def test_admin_dashboard(request):
+    if not settings.DEBUG:
+        raise Http404
+    ...
+```
+
+Nota relacionada (no bloqueante, va en `chore/frontend-consistency`, SEC-018): las páginas de error enlazan a `admin_dashboard`, revelando la URL del panel a anónimos.
+
+## Verificación
+
+```bash
+pytest tests/integration/ -q
+# Comprobar manualmente que GET /test/admin/ devuelve 404 (o requiere superusuario)
+```
+
+Añadir un test de integración: GET `/test/admin/` como anónimo → 404/403.
+
+## Commits sugeridos
+
+```
+fix(auctions): remove unauthenticated test admin dashboard view
+```
+
+## Criterios de done
+
+- [ ] SEC-004 resuelto; `/test/admin/` ya no expone datos a anónimos
+- [ ] Test que lo verifica; cobertura ≥ 70%
+- [ ] `pr-validate` en verde; PR a `develop`; fila actualizada en el [tablero](README.md)

--- a/docs/tasks/p2-fix-xss-templates.md
+++ b/docs/tasks/p2-fix-xss-templates.md
@@ -1,0 +1,68 @@
+# Tarea: `fix/xss-templates` — XSS en plantillas y saneo de contenido externo
+
+> **Prioridad:** 2 (Alto) · **Rama base:** `develop` · **Merge:** Squash and merge · **Estado:** Pendiente
+> **Detalle de hallazgos:** [../audits/security.md](../audits/security.md)
+
+## Objetivo
+
+Eliminar el vector de XSS almacenado de los datos de BD inyectados con `|safe` dentro de `<script>` en el panel admin, y endurecer el contenido externo: URLs de imagen de usuario que permiten `http://` y recursos de CDN sin verificación de integridad.
+
+## Rama
+
+```bash
+git checkout develop && git pull
+git checkout -b fix/xss-templates
+```
+
+## Hallazgos a resolver
+
+- [ ] **SEC-009** — Datos de BD con `|safe` dentro de `<script>` (`auctions/templates/auctions/admin/analytics.html:242,275,328`, `reports.html:340`)
+- [ ] **SEC-013** — `image` de usuario permite `http://` (`auctions/forms.py:52-61`, render en `auction.html:27`, `card.html:34`)
+- [ ] **SEC-014** — CDN sin SRI; `plotly-latest.min.js` sin versión fija (`layout.html:28-37`, `admin/base.html:19-25,132`)
+
+## Instrucciones / recomendaciones
+
+1. **SEC-009 (`json_script`).** Reemplazar `{{ data|safe }}` dentro de `<script>` por el filtro seguro `json_script`, que escapa correctamente y produce JSON válido:
+
+   ```django
+   {{ market_trends.monthly_trends|json_script:"market-trends-data" }}
+   ```
+   ```js
+   const marketTrendsData = JSON.parse(
+       document.getElementById("market-trends-data").textContent
+   );
+   ```
+
+   Aplicar a los tres archivos. Los divs Plotly de `dashboard.html:130,142,157` son HTML generado por Plotly (menor riesgo), pero conviene verificar que ningún label proviene de entrada de usuario sin escapar.
+
+2. **SEC-013 (URL de imagen).** En `forms.clean_image`, restringir el esquema a `https://` (evita contenido mixto en el sitio HTTPS) y validar el host si se quiere. Considerar un `onerror` de fallback en las plantillas (se solapa con UX-006 en `chore/frontend-consistency`).
+
+3. **SEC-014 (SRI + pinning).** Añadir `integrity="sha384-..."` y `crossorigin="anonymous"` a los `<link>`/`<script>` de CDN, y fijar `plotly-latest.min.js` a una versión concreta. Alternativa más robusta: vendorizar Bootstrap/FA localmente y servirlos con WhiteNoise.
+
+## Tests requeridos
+
+- Test de que un título/categoría con `</script>` no rompe ni ejecuta en las plantillas admin (render sin `|safe`).
+- Test de que `clean_image` rechaza URLs `http://`.
+
+## Verificación
+
+```bash
+pytest tests/unit/test_forms.py tests/integration/ -q
+bandit -r auctions/ -ll
+# Revisar manualmente el HTML renderizado del panel admin: no debe haber datos sin escapar en <script>
+```
+
+## Commits sugeridos
+
+```
+fix(auctions): use json_script for admin chart data
+fix(auctions): require https scheme for listing image urls
+fix(auctions): add SRI hashes and pin CDN assets
+```
+
+## Criterios de done
+
+- [ ] Sin `|safe` sobre datos de BD dentro de `<script>`
+- [ ] URLs de imagen restringidas a `https`
+- [ ] Recursos de CDN con SRI y versión fija
+- [ ] Tests verdes; `pr-validate` en verde; PR a `develop`; fila actualizada en el [tablero](README.md)

--- a/docs/tasks/p3-chore-settings-hardening.md
+++ b/docs/tasks/p3-chore-settings-hardening.md
@@ -1,0 +1,66 @@
+# Tarea: `chore/settings-hardening` — Endurecer configuración de producción
+
+> **Prioridad:** 3 (Medio) · **Rama base:** `develop` · **Merge:** Squash and merge · **Estado:** Pendiente
+> **Detalle de hallazgos:** [../audits/security.md](../audits/security.md)
+
+## Objetivo
+
+Completar la configuración de seguridad de Django para producción: forzado de HTTPS y detección correcta tras proxy, orígenes CSRF confiables, logging, y ajustes de cookies/headers. Ninguno es explotable por sí solo, pero juntos cierran la superficie de despliegue.
+
+## Rama
+
+```bash
+git checkout develop && git pull
+git checkout -b chore/settings-hardening
+```
+
+## Hallazgos a resolver
+
+- [ ] **SEC-010** — Faltan `SECURE_SSL_REDIRECT`, `SECURE_PROXY_SSL_HEADER`, `CSRF_TRUSTED_ORIGINS` (`commerce/settings.py:118-128`)
+- [ ] **SEC-012** — Sin configuración `LOGGING`
+- [ ] **SEC-015** — `SECURE_BROWSER_XSS_FILTER` obsoleto (`commerce/settings.py:120`)
+- [ ] **SEC-016** — Cookies: sin `SESSION_COOKIE_HTTPONLY` explícito ni `SESSION_COOKIE_AGE`
+- [ ] **SEC-017** — `except Exception` con `str(e)` al contexto de plantilla (fuga de detalles)
+
+## Instrucciones / recomendaciones
+
+1. **SEC-010.** Dentro del bloque `if not DEBUG` de `settings.py`, añadir:
+   ```python
+   SECURE_SSL_REDIRECT = True
+   SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+   CSRF_TRUSTED_ORIGINS = os.getenv("CSRF_TRUSTED_ORIGINS", "").split(",")
+   ```
+   `SECURE_PROXY_SSL_HEADER` es imprescindible tras Heroku/nginx para que Django detecte HTTPS y no entre en bucles de redirección ni emita cookies inseguras.
+
+2. **SEC-012.** Añadir un `LOGGING` dict con handler a consola (Heroku captura stdout) y nivel configurable por env. Sirve también para dejar de silenciar los fallos de analítica (ver `fix/analytics-postgres`).
+
+3. **SEC-015.** Eliminar `SECURE_BROWSER_XSS_FILTER` (el header `X-XSS-Protection` está desaconsejado por los navegadores modernos).
+
+4. **SEC-016.** `SESSION_COOKIE_HTTPONLY = True` explícito y un `SESSION_COOKIE_AGE` razonable.
+
+5. **SEC-017.** No pasar `str(e)` a la plantilla; loguear la excepción y mostrar un mensaje genérico.
+
+## Tests requeridos
+
+- **TEST-005:** test de cabeceras de seguridad con `DEBUG=False` (HSTS, `X-Frame-Options`, `Secure` en cookies, redirección SSL).
+
+## Verificación
+
+```bash
+python manage.py check --deploy   # no debe reportar los warnings corregidos
+pytest tests/integration/ -q
+```
+
+## Commits sugeridos
+
+```
+chore(commerce): add SSL redirect, proxy header and trusted origins
+chore(commerce): add production logging configuration
+chore(commerce): tighten session cookie settings
+```
+
+## Criterios de done
+
+- [ ] `manage.py check --deploy` sin los warnings relevantes
+- [ ] Test de cabeceras de seguridad verde
+- [ ] `pr-validate` en verde; PR a `develop`; fila actualizada en el [tablero](README.md)

--- a/docs/tasks/p3-refactor-model-constraints.md
+++ b/docs/tasks/p3-refactor-model-constraints.md
@@ -1,0 +1,72 @@
+# Tarea: `refactor/model-constraints` — Constraints e índices de modelo
+
+> **Prioridad:** 3 (Medio) · **Rama base:** `develop` · **Merge:** Squash and merge · **Estado:** Pendiente
+> **Detalle de hallazgos:** [../audits/code-quality.md](../audits/code-quality.md) · [../audits/performance.md](../audits/performance.md)
+
+## Objetivo
+
+Llevar a la base de datos las garantías que hoy solo viven (o no viven) en código: `on_delete` correcto en `winner`, constraints de integridad, unicidad de watchlist, unicidad de título, y los índices de las columnas de filtro/orden calientes. Una sola migración cubre constraints e índices.
+
+## Rama
+
+```bash
+git checkout develop && git pull
+git checkout -b refactor/model-constraints
+```
+
+## Hallazgos a resolver
+
+- [ ] **CODE-003** — `Listing.winner` con `on_delete=CASCADE` (`auctions/models.py:23-29`)
+- [ ] **CODE-005** — Modelos sin `Meta`: sin índices, constraints, `unique_together`
+- [ ] **CODE-006** — Unicidad de `title` solo en el form (TOCTOU, `auctions/forms.py:30-36`)
+- [ ] **PERF-006** — Sin índices en `active`, `category`, `created`, `amount`
+
+## Instrucciones / recomendaciones
+
+1. **CODE-003.** Cambiar `winner` a `on_delete=models.SET_NULL` (ya es `null=True, blank=True`).
+
+2. **CODE-005 + PERF-006.** Añadir `class Meta` a los modelos:
+   ```python
+   class Meta:
+       indexes = [
+           models.Index(fields=["active"]),
+           models.Index(fields=["category"]),
+           models.Index(fields=["-created"]),
+       ]
+       constraints = [
+           models.CheckConstraint(check=Q(starting_bid__gte=0), name="starting_bid_gte_0"),
+       ]
+   ```
+   Para `Watchlist`: `UniqueConstraint(fields=["user", "listing"], name="uniq_watchlist_user_listing")`. Para `Bid`: `CheckConstraint(amount__gt=0)`.
+
+3. **CODE-006.** Añadir `unique=True` a `Listing.title` en el modelo (respaldo de BD para la validación del form, que deja de ser un TOCTOU). Valorar si la unicidad de título es realmente deseable de negocio antes de imponerla; si lo es, la constraint de BD es la fuente de verdad y el form solo da el mensaje amigable.
+
+4. Generar la migración: `python manage.py makemigrations auctions`. Revisar que no rompa datos existentes (p. ej. títulos duplicados previos si se impone `unique`).
+
+## Tests requeridos
+
+- Test de que un `Bid`/`starting_bid` inválido es rechazado por la BD (`IntegrityError`).
+- Test de que no se pueden crear dos `Watchlist` con el mismo `(user, listing)`.
+- Test de que borrar un usuario ganador **no** borra el listing (queda `winner=NULL`).
+
+## Verificación
+
+```bash
+python manage.py makemigrations --check --dry-run   # debe existir la migración
+pytest tests/unit/test_models.py -q
+mypy auctions/
+```
+
+## Commits sugeridos
+
+```
+refactor(auctions): set winner on_delete to SET_NULL
+refactor(auctions): add model indexes and check constraints
+refactor(auctions): enforce unique watchlist and listing title at DB
+```
+
+## Criterios de done
+
+- [ ] Migración creada y aplicada sin pérdida de datos
+- [ ] Constraints/índices/unicidad verificados por test
+- [ ] `pr-validate` en verde; PR a `develop`; fila actualizada en el [tablero](README.md)

--- a/docs/tasks/p3-refactor-query-performance.md
+++ b/docs/tasks/p3-refactor-query-performance.md
@@ -1,0 +1,72 @@
+# Tarea: `refactor/query-performance` — Optimización de consultas
+
+> **Prioridad:** 3 (Medio) · **Rama base:** `develop` · **Merge:** Squash and merge · **Estado:** Pendiente
+> **Detalle de hallazgos:** [../audits/performance.md](../audits/performance.md)
+
+## Objetivo
+
+Eliminar los patrones N+1 y las agregaciones hechas en Python, y corregir los conteos multiplicados del panel admin. Conviene hacerla **después** de `refactor/model-constraints` (los índices de PERF-006 amplifican estas mejoras).
+
+## Rama
+
+```bash
+git checkout develop && git pull
+git checkout -b refactor/query-performance
+```
+
+## Hallazgos a resolver
+
+- [ ] **PERF-001** — `Count()` múltiple sin `distinct=True` → conteos multiplicados (`auctions/admin_views.py:42-47,170-174`)
+- [ ] **PERF-002** — `generate_user_activity_report` O(N·5) queries (`auctions/data_utils.py:125-147`)
+- [ ] **PERF-003** — `admin_export_data` sin límite/streaming (`auctions/admin_views.py:326-408`)
+- [ ] **PERF-004** — N+1 en comentarios (`auctions/views.py:103`, `auction.html:230`)
+- [ ] **PERF-005** — Query de categorías por request sin caché (`auctions/views.py:210-216`)
+- [ ] **PERF-007** — `generate_market_analysis` suma en Python en vez de `Avg` (`auctions/data_utils.py:171-176`)
+- [ ] **PERF-008** — Listados sin `select_related("user")` (`auctions/views.py:16,157,197`)
+
+## Instrucciones / recomendaciones
+
+1. **PERF-001 (crítico funcional).** Añadir `distinct=True` a cada `Count`:
+   ```python
+   User.objects.annotate(
+       total_activity=Count("bids", distinct=True)
+                    + Count("listings", distinct=True)
+                    + Count("comments", distinct=True)
+   )
+   ```
+   Sin esto los conteos del dashboard/`admin_users` son incorrectos por fan-out de JOINs.
+
+2. **PERF-004 + PERF-008.** Añadir `select_related("user")` en `auction.comments.select_related("user").all()` (`views.py:103`) y en los listados que la plantilla vaya a recorrer por FK.
+
+3. **PERF-002 + PERF-007.** Reemplazar los bucles con `.count()`/`sum()` por una única query con `annotate(Count(..., distinct=True))` / `aggregate(Avg(...))`.
+
+4. **PERF-003.** Usar `QuerySet.iterator()` + `StreamingHttpResponse` en la exportación, o paginar.
+
+5. **PERF-005.** Cachear la lista de categorías (framework de caché de Django) o resolverla con el índice de `category` (creado en `refactor/model-constraints`).
+
+## Tests requeridos
+
+- **TEST-007:** `assertNumQueries` en la vista de detalle de listing con N comentarios (debe ser constante, no crecer con N).
+- Test de que los conteos de actividad del admin son correctos con datos conocidos (PERF-001).
+
+## Verificación
+
+```bash
+pytest tests/integration/ -q
+# Opcional: django-debug-toolbar (ya en requirements-dev.txt) para inspeccionar queries reales
+```
+
+## Commits sugeridos
+
+```
+perf(auctions): use distinct counts in admin annotations
+perf(auctions): select_related user in comment and listing queries
+perf(auctions): aggregate reports in the database
+perf(auctions): stream admin data export
+```
+
+## Criterios de done
+
+- [ ] Conteos del admin correctos; N+1 de comentarios eliminado (verificado con `assertNumQueries`)
+- [ ] Exportación acotada en memoria
+- [ ] `pr-validate` en verde; PR a `develop`; fila actualizada en el [tablero](README.md)

--- a/docs/tasks/p4-chore-deps-and-tests.md
+++ b/docs/tasks/p4-chore-deps-and-tests.md
@@ -1,0 +1,67 @@
+# Tarea: `chore/deps-and-tests` — Dependencias, tooling y cobertura de tests
+
+> **Prioridad:** 4 (Bajo) · **Rama base:** `develop` · **Merge:** Squash and merge · **Estado:** Pendiente
+> **Detalle de hallazgos:** [../audits/code-quality.md](../audits/code-quality.md) · [../audits/testing-and-ci.md](../audits/testing-and-ci.md)
+
+## Objetivo
+
+Sanear el tooling y cerrar los huecos de la suite de tests y del CI: fijar dependencias, retirar código muerto y deps sin uso, eliminar la suite legacy duplicada, ampliar la cobertura a los módulos frágiles y reforzar el pipeline. No toca código de la app salvo tests, así que puede ir en paralelo con otras ramas.
+
+## Rama
+
+```bash
+git checkout develop && git pull
+git checkout -b chore/deps-and-tests
+```
+
+## Hallazgos a resolver
+
+- [ ] **CODE-007** — Dependencias con `>=` sin lockfile (`requirements.txt`)
+- [ ] **CODE-008** — `Custom404Middleware` código muerto (`auctions/middleware.py:64-86`, guard sobre setting inexistente)
+- [ ] **CODE-009** — `django-import-export` instalado sin uso (`commerce/settings.py:30`)
+- [ ] **CODE-010** — `mypy`: asignación incompatible en config de BD (`commerce/settings.py:84`)
+- [ ] **TEST-001** — Sin test de concurrencia para `place_bid`
+- [ ] **TEST-002** — Cobertura omite `admin_views.py`/`analytics.py`/`data_utils.py`
+- [ ] **TEST-003** — Suite legacy duplicada `auctions/tests/` fuera de `testpaths`
+- [ ] **TEST-004** — `tests/e2e/` vacío; `fixtures/axe.min.js` sin trackear
+- [ ] **TEST-005** — Sin tests de cabeceras de seguridad
+- [ ] **TEST-007** — Sin `assertNumQueries` para regresiones N+1
+- [ ] **TEST-008** — `safety` no bloqueante; sin a11y/perf/escaneo de contenedor/CodeQL en CI
+
+## Instrucciones / recomendaciones
+
+1. **CODE-007.** Fijar versiones (`==`) o adoptar un lockfile (`pip-tools`/`uv`). Como mínimo, poner topes superiores.
+2. **CODE-008.** Eliminar `Custom404Middleware` (o el guard muerto) y quitarlo de `MIDDLEWARE` en `settings.py:45`.
+3. **CODE-009.** Retirar `import_export` de `INSTALLED_APPS` si no se usa, o implementarlo en `admin.py`.
+4. **CODE-010.** Corregir la anotación de tipos / uso de `dj_database_url` para que `mypy` pase limpio.
+5. **TEST-003.** Eliminar `auctions/tests/` (suite legacy no recolectada) tras confirmar que `tests/` cubre lo mismo. Esto también elimina los 13 avisos Low de bandit.
+6. **TEST-002.** Retirar `admin_views.py`/`analytics.py`/`data_utils.py` del `omit` de cobertura y añadir tests (coordinar con `fix/analytics-postgres`).
+7. **TEST-001/005/007.** Añadir los tests de concurrencia, cabeceras de seguridad y `assertNumQueries` (algunos se entregan junto a sus ramas de fix; aquí se consolida lo que quede).
+8. **TEST-004.** Escribir al menos un flujo e2e con Playwright + `axe-core` (el fixture ya está en `tests/e2e/fixtures/`), y trackearlo correctamente (hoy es propiedad de root y sin trackear).
+9. **TEST-008.** Hacer `safety` bloqueante en `pr-validate.yml` y valorar añadir escaneo de imagen (Trivy) y/o CodeQL.
+
+## Verificación
+
+```bash
+pytest -q                      # incluye los módulos antes omitidos
+ruff check . && black --check . && mypy auctions/   # mypy limpio (CODE-010)
+bandit -r auctions/ -ll        # sin avisos de la suite legacy eliminada
+```
+
+## Commits sugeridos
+
+```
+build(deps): pin dependency versions
+chore(auctions): remove dead Custom404Middleware
+chore(commerce): drop unused import_export app
+chore(commerce): fix database config type for mypy
+test(tests): remove legacy duplicate test suite
+test(tests): cover admin, analytics and security headers
+ci(ci): make safety blocking and add container scan
+```
+
+## Criterios de done
+
+- [ ] Dependencias fijadas; código muerto y deps sin uso retirados; `mypy` limpio
+- [ ] Suite legacy eliminada; cobertura amplía a los módulos frágiles
+- [ ] `pr-validate` en verde; PR a `develop`; fila actualizada en el [tablero](README.md)

--- a/docs/tasks/p4-chore-frontend-consistency.md
+++ b/docs/tasks/p4-chore-frontend-consistency.md
@@ -1,0 +1,77 @@
+# Tarea: `chore/frontend-consistency` — Consistencia y limpieza de frontend
+
+> **Prioridad:** 4 (Bajo) · **Rama base:** `develop` · **Merge:** Squash and merge · **Estado:** Pendiente
+> **Detalle de hallazgos:** [../audits/ui-ux.md](../audits/ui-ux.md) · [../audits/accessibility.md](../audits/accessibility.md) · [../audits/security.md](../audits/security.md)
+
+## Objetivo
+
+Pulir la UI: retirar la UI muerta (controles que no hacen nada), unificar versiones y formatos, dar consistencia a fechas/moneda, y limpiar restos de depuración. Cambios de bajo riesgo y alto impacto en percepción de calidad.
+
+## Rama
+
+```bash
+git checkout develop && git pull
+git checkout -b chore/frontend-consistency
+```
+
+## Hallazgos a resolver
+
+- [ ] **UX-001** — Formulario de filtros del index sin `name`/`action` (`index.html:29-60`)
+- [ ] **UX-002** — Include a `mini_card.html` inexistente (`index.html:110`)
+- [ ] **UX-003** — Cierre de subasta sin confirmación (`auction.html:144-149`)
+- [ ] **UX-004** — Bootstrap 5.3.3 vs 5.3.0; FA 6.0.0 vs 6.4.0
+- [ ] **UX-005** — Moneda sin `floatformat:2` en admin
+- [ ] **UX-006** — Imágenes de URL sin `onerror` fallback
+- [ ] **UX-007** — Mensajes admin con `alert-{{ tags }}` → `alert-error` sin estilo (`admin/base.html:114`)
+- [ ] **UX-008** — Plantillas referencian atributos inexistentes (`bids_count`, `is_new`, …)
+- [ ] **UX-009** — Seis formatos de fecha distintos
+- [ ] **UX-010** — Enlaces de footer son anclas `#` muertas
+- [ ] **UX-011** — `console.log` en `layout.js:79,100,114,285`
+- [ ] **UX-012** — Login/register usan `message` genérico, no el framework de mensajes
+- [ ] **A11Y-009** — Enlace "View" sin nombre accesible en móvil (`card.html:91-94`)
+- [ ] **A11Y-011** — Controles solo-ícono en admin sin `aria-label`
+- [ ] **A11Y-012** — Íconos FA decorativos sin `aria-hidden` consistente
+- [ ] **A11Y-013** — `aria-live="assertive"` para todos los mensajes (`alert.html:6`)
+- [ ] **A11Y-014** — `maximum-scale=5.0` restringe el zoom
+- [ ] **SEC-018** — Páginas de error enlazan a `admin_dashboard` (revela URL admin)
+
+## Instrucciones / recomendaciones
+
+- **UX-001:** conectar el formulario a la vista `categories` existente (`views.py:194-219`, que ya filtra y calcula categorías) con `name`/`action`/`method`, o retirar el control hasta implementarlo.
+- **UX-002:** crear `mini_card.html` o eliminar el bloque "Recently Viewed".
+- **UX-003:** añadir `confirm()` o modal antes del submit de cierre (combinar con el cambio a POST de SEC-005 si aún no se hizo).
+- **UX-004:** unificar a una sola versión de Bootstrap y FA en `layout.html` y `admin/base.html`.
+- **UX-005/UX-009:** definir un formato único de moneda (`|floatformat:2`) y de fecha; aplicarlo en todos los templates. Considerar un template filter o `DATE_FORMAT` global.
+- **UX-006:** `onerror` que muestre el placeholder ya existente.
+- **UX-007:** mapear `error`→`danger` en `admin/base.html` como hace `components/alert.html:9`.
+- **UX-008:** retirar las referencias a atributos inexistentes o anotarlos en la vista.
+- **UX-011:** quitar los `console.log`.
+- **A11Y-009/011/012:** añadir `aria-label` a controles solo-ícono y `aria-hidden="true"` a los íconos decorativos.
+- **A11Y-013:** `aria-live="polite"` salvo para errores críticos.
+- **A11Y-014:** quitar `maximum-scale` del viewport.
+- **SEC-018:** quitar el enlace a `admin_dashboard` de las páginas de error públicas.
+
+## Verificación
+
+```bash
+pytest tests/integration/ -q
+ruff check . && black --check .
+# Revisar manualmente: filtros del index, cierre con confirmación, alertas admin con estilo
+```
+
+## Commits sugeridos
+
+```
+fix(auctions): wire index filters to categories view
+chore(auctions): unify bootstrap and font-awesome versions
+style(auctions): consistent currency and date formatting
+fix(auctions): map admin error messages to bootstrap danger class
+chore(auctions): remove debug console.log and dead UI references
+fix(auctions): add aria labels and fix decorative icon semantics
+```
+
+## Criterios de done
+
+- [ ] Sin UI muerta ni `console.log`; versiones y formatos unificados
+- [ ] Controles accesibles (aria) y alertas admin con estilo
+- [ ] `pr-validate` en verde; PR a `develop`; fila actualizada en el [tablero](README.md)


### PR DESCRIPTION
## Contexto

Continuación de la auditoría (#57, ya mergeada). Convierte el roadmap de remediación en un **backlog accionable y trackeable**, añade una guía operativa para agentes de IA y corrige desfases de exactitud en `CLAUDE.md`. Solo documentación.

## Qué incluye

- **`docs/tasks/`** — tablero por prioridad (`README.md`) + **10 fichas** (una por rama/PR sugerido). Cada ficha: objetivo, comandos para crear la rama, checklist de hallazgos enlazado a `docs/audits/`, instrucciones/recomendaciones, tests requeridos, verificación y commits sugeridos.
- **`AGENTS.md`** — punto de entrada neutral (estándar agents.md): flujo de trabajo, quality gates, mapa del código, backlog y "qué NO hacer". Remite a `CLAUDE.md` sin duplicar sus tablas.
- **`CLAUDE.md`** — correcciones de exactitud: conteo de vistas (12 públicas + panel admin/BI), `cd-develop` deshabilitado (`workflow_dispatch`), Python target vs runtime `python:3.12`, `tests/e2e/` vacío + nota de la suite legacy, scope `docs` ampliado, y nueva sección de backlog/auditoría.

## Backlog (10 ramas priorizadas)

| Prioridad | Ramas |
|:-:|---|
| 1 | `fix/security-critical`, `fix/analytics-postgres` |
| 2 | `fix/admin-routing`, `fix/xss-templates`, `fix/a11y-css-variables` |
| 3 | `chore/settings-hardening`, `refactor/model-constraints`, `refactor/query-performance` |
| 4 | `chore/frontend-consistency`, `chore/deps-and-tests` |

## Verificación

- Enlaces internos resueltos (incluidos `../audits/*.md`, presentes en `develop` tras #57).
- Las 10 fichas cubren las 10 ramas del roadmap; conteos por prioridad 2/3/3/2.
- Sin emoji decorativo en los nuevos docs.

## Notas

- Merge sugerido: **Squash and merge** (rama `docs/*` → `develop`).