### PR TITLE
fix(auctions): make analytics work on PostgreSQL

### DIFF
--- a/auctions/admin_views.py
+++ b/auctions/admin_views.py
@@ -3,6 +3,8 @@ Vistas del panel de administración para superusuarios
 Dashboard de Business Intelligence para gestión de subastas
 """
 
+import logging
+
 from django.contrib import messages
 from django.contrib.auth.decorators import user_passes_test
 from django.core.paginator import Paginator
@@ -13,6 +15,8 @@ from django.utils import timezone
 
 from .analytics import AuctionAnalytics
 from .models import Bid, Listing, User
+
+logger = logging.getLogger(__name__)
 
 
 def is_superuser(user):
@@ -56,6 +60,7 @@ def admin_dashboard(request):
 
         return render(request, "auctions/admin/dashboard.html", context)
     except Exception as e:
+        logger.exception("Failed to build admin dashboard analytics")
         # En caso de error, mostrar una página simple de administración
         context = {
             "page_title": "Dashboard de Administración",

--- a/auctions/analytics.py
+++ b/auctions/analytics.py
@@ -5,22 +5,21 @@ Implementa métodos de data science para análisis de subastas
 
 from datetime import timedelta
 
-try:
-    import numpy as np
-    import pandas as pd
-    import plotly.express as px
-    import plotly.graph_objects as go
-    from plotly.offline import plot
-    from sklearn.linear_model import LinearRegression
-    from sklearn.preprocessing import StandardScaler
-except ImportError:
-    np = pd = px = go = plot = LinearRegression = StandardScaler = None  # type: ignore[assignment]
-
-from django.contrib.auth.models import User
+import numpy as np
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+from django.contrib.auth import get_user_model
 from django.db.models import Avg, Count, F, Q, Sum
+from django.db.models.functions import ExtractMonth, TruncDate, TruncMonth
 from django.utils import timezone
+from plotly.offline import plot
+from sklearn.linear_model import LinearRegression
+from sklearn.preprocessing import StandardScaler
 
 from .models import Bid, Comment, Listing, Watchlist
+
+User = get_user_model()
 
 
 class AuctionAnalytics:
@@ -81,7 +80,7 @@ class AuctionAnalytics:
         # Listings por día
         listings_by_day = (
             Listing.objects.filter(created__gte=start_date)
-            .extra(select={"day": "date(created)"})
+            .annotate(day=TruncDate("created"))
             .values("day")
             .annotate(count=Count("id"))
             .order_by("day")
@@ -90,7 +89,7 @@ class AuctionAnalytics:
         # Bids por día
         bids_by_day = (
             Bid.objects.filter(listing__created__gte=start_date)
-            .extra(select={"day": "date(listing__created)"})
+            .annotate(day=TruncDate("listing__created"))
             .values("day")
             .annotate(count=Count("id"), total_amount=Sum("amount"))
             .order_by("day")
@@ -99,16 +98,19 @@ class AuctionAnalytics:
         # Usuarios registrados por día
         users_by_day = (
             User.objects.filter(date_joined__gte=start_date)
-            .extra(select={"day": "date(date_joined)"})
+            .annotate(day=TruncDate("date_joined"))
             .values("day")
             .annotate(count=Count("id"))
             .order_by("day")
         )
 
+        def _serialize_by_day(rows):
+            return [{**row, "day": row["day"].isoformat()} for row in rows]
+
         return {
-            "listings": list(listings_by_day),
-            "bids": list(bids_by_day),
-            "users": list(users_by_day),
+            "listings": _serialize_by_day(listings_by_day),
+            "bids": _serialize_by_day(bids_by_day),
+            "users": _serialize_by_day(users_by_day),
         }
 
     def get_category_analysis(self):
@@ -280,7 +282,7 @@ class AuctionAnalytics:
         """
         # Análisis mensual
         monthly_data = (
-            Listing.objects.extra(select={"month": 'strftime("%Y-%m", created)'})
+            Listing.objects.annotate(month=TruncMonth("created"))
             .values("month")
             .annotate(
                 listings_count=Count("id"),
@@ -293,15 +295,19 @@ class AuctionAnalytics:
 
         # Análisis de estacionalidad
         seasonal_data = (
-            Listing.objects.extra(select={"month": 'strftime("%m", created)'})
+            Listing.objects.annotate(month=ExtractMonth("created"))
             .values("month")
             .annotate(count=Count("id"))
             .order_by("month")
         )
 
         return {
-            "monthly_trends": list(monthly_data),
-            "seasonal_patterns": list(seasonal_data),
+            "monthly_trends": [
+                {**row, "month": row["month"].strftime("%Y-%m")} for row in monthly_data
+            ],
+            "seasonal_patterns": [
+                {**row, "month": f"{row['month']:02d}"} for row in seasonal_data
+            ],
         }
 
     def generate_plotly_charts(self):

--- a/auctions/templates/auctions/admin/listing_detail.html
+++ b/auctions/templates/auctions/admin/listing_detail.html
@@ -1,5 +1,6 @@
 {% extends "auctions/admin/base.html" %}
 {% load static %}
+{% load auctions_filters %}
 
 {% block admin_content %}
 <!-- Información de la subasta -->

--- a/auctions/templates/auctions/admin/listings.html
+++ b/auctions/templates/auctions/admin/listings.html
@@ -1,5 +1,6 @@
 {% extends "auctions/admin/base.html" %}
 {% load static %}
+{% load auctions_filters %}
 
 {% block admin_content %}
 <!-- Filtros y búsqueda -->

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -33,8 +33,8 @@ Convenciones completas: [CLAUDE.md](../../CLAUDE.md) · Guía operativa para age
 
 | Rama | Área | Hallazgos | Esfuerzo | Estado | Ficha |
 |------|------|-----------|:--------:|--------|-------|
-| `fix/security-critical` | Seguridad | SEC-001,002,003,005,006,007,008,011 · CODE-004 | M | En progreso | [p1-fix-security-critical.md](p1-fix-security-critical.md) |
-| `fix/analytics-postgres` | Correctitud | CODE-001, CODE-002 | L | Pendiente | [p1-fix-analytics-postgres.md](p1-fix-analytics-postgres.md) |
+| `fix/security-critical` | Seguridad | SEC-001,002,003,005,006,007,008,011 · CODE-004 | M | Hecho | [p1-fix-security-critical.md](p1-fix-security-critical.md) |
+| `fix/analytics-postgres` | Correctitud | CODE-001, CODE-002 | L | En progreso | [p1-fix-analytics-postgres.md](p1-fix-analytics-postgres.md) |
 
 ## Prioridad 2 — Alto
 

--- a/docs/tasks/p1-fix-analytics-postgres.md
+++ b/docs/tasks/p1-fix-analytics-postgres.md
@@ -1,6 +1,6 @@
 # Tarea: `fix/analytics-postgres` — Analítica funcional en PostgreSQL
 
-> **Prioridad:** 1 (Crítico) · **Rama base:** `develop` · **Merge:** Squash and merge · **Estado:** Pendiente
+> **Prioridad:** 1 (Crítico) · **Rama base:** `develop` · **Merge:** Squash and merge · **Estado:** En progreso
 > **Detalle de hallazgos:** [../audits/code-quality.md](../audits/code-quality.md)
 
 ## Objetivo
@@ -16,8 +16,8 @@ git checkout -b fix/analytics-postgres
 
 ## Hallazgos a resolver
 
-- [ ] **CODE-001** — `analytics.py` importa `django.contrib.auth.models.User` + `.extra()` solo-SQLite (`auctions/analytics.py:19,84,93,102,283,296`)
-- [ ] **CODE-002** — `numpy`/`pandas` ausentes de `requirements.txt` (`auctions/data_utils.py:8`, `management/commands/generate_reports.py:86`)
+- [x] **CODE-001** — `analytics.py` importa `django.contrib.auth.models.User` + `.extra()` solo-SQLite (`auctions/analytics.py:19,84,93,102,283,296`)
+- [x] **CODE-002** — `numpy`/`pandas` ausentes de `requirements.txt` (`auctions/data_utils.py:8`, `management/commands/generate_reports.py:86`)
 
 ## Instrucciones / recomendaciones
 
@@ -65,7 +65,7 @@ build(deps): move pandas and numpy to runtime requirements
 
 ## Criterios de done
 
-- [ ] Analítica funciona en PostgreSQL sin excepciones
-- [ ] Imports de `numpy`/`pandas` resueltos en la imagen de producción
-- [ ] Tests de analítica en la suite (fuera del `omit`); cobertura ≥ 70%
+- [x] Analítica funciona en PostgreSQL sin excepciones (verificado contra PostgreSQL 16 real)
+- [x] Imports de `numpy`/`pandas` resueltos en la imagen de producción (movidos a `requirements.txt`)
+- [x] Tests de analítica en la suite (fuera del `omit`); cobertura ≥ 70% (86.04%)
 - [ ] `pr-validate` en verde; PR a `develop`; fila actualizada en el [tablero](README.md)

--- a/docs/tasks/p1-fix-security-critical.md
+++ b/docs/tasks/p1-fix-security-critical.md
@@ -1,6 +1,6 @@
 # Tarea: `fix/security-critical` — Correcciones críticas de seguridad
 
-> **Prioridad:** 1 (Crítico) · **Rama base:** `develop` · **Merge:** Squash and merge · **Estado:** En progreso
+> **Prioridad:** 1 (Crítico) · **Rama base:** `develop` · **Merge:** Squash and merge · **Estado:** Hecho ([PR #61](https://github.com/sandovaldavid/auctions/pull/61))
 > **Detalle de hallazgos:** [../audits/security.md](../audits/security.md) · [../audits/code-quality.md](../audits/code-quality.md)
 
 ## Objetivo
@@ -86,5 +86,5 @@ fix(auctions): use get_object_or_404 and POST.get in views
 
 - [x] Todos los checkboxes de hallazgos marcados
 - [x] Tests nuevos verdes; cobertura ≥ 70% (82.22% local, verificado también contra PostgreSQL 16)
-- [ ] `pr-validate` en verde
-- [ ] PR a `develop` con "Squash and merge"; fila actualizada en el [tablero](README.md)
+- [x] `pr-validate` en verde
+- [x] PR a `develop` con "Squash and merge"; fila actualizada en el [tablero](README.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,9 +83,6 @@ omit = [
     "*/tests/*",
     "*/settings*",
     "manage.py",
-    "auctions/admin_views.py",
-    "auctions/analytics.py",
-    "auctions/data_utils.py",
     "auctions/admin_config.py",
     "auctions/management/commands/generate_reports.py",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,9 +22,3 @@ safety>=3.0
 django-debug-toolbar>=4.4
 django-extensions>=3.2
 ipython>=8.0
-
-# Data / BI (future features)
-pandas>=2.2
-numpy>=1.26
-plotly>=5.17
-scikit-learn>=1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,9 @@ whitenoise>=6.8
 sqlparse>=0.5
 tzdata>=2024.2
 django-import-export>=4.1
+
+# Data / BI (admin analytics dashboard)
+pandas>=2.2
+numpy>=1.26
+plotly>=5.17
+scikit-learn>=1.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,5 +80,10 @@ def another_user(db):
 
 
 @pytest.fixture
+def superuser(db):
+    return UserFactory(username="admin_user", is_staff=True, is_superuser=True)
+
+
+@pytest.fixture
 def listing(db, user):
     return ListingFactory(user=user)

--- a/tests/integration/test_admin_views.py
+++ b/tests/integration/test_admin_views.py
@@ -1,0 +1,139 @@
+from decimal import Decimal
+
+import pytest
+from django.urls import reverse
+
+from tests.conftest import BidFactory, ListingFactory
+
+
+@pytest.mark.django_db
+class TestAdminAccessControl:
+    def test_admin_dashboard_requires_login(self, client):
+        response = client.get(reverse("admin_dashboard"))
+        assert response.status_code == 302
+        assert "/login" in response.url
+
+    def test_admin_dashboard_requires_superuser(self, client, user):
+        client.force_login(user)
+        response = client.get(reverse("admin_dashboard"))
+        assert response.status_code == 302
+        assert "/login" in response.url
+
+
+@pytest.mark.django_db
+class TestAdminDashboardAndAnalytics:
+    def test_admin_dashboard_renders_for_superuser(self, client, superuser, listing):
+        BidFactory(listing=listing)
+        client.force_login(superuser)
+        response = client.get(reverse("admin_dashboard"))
+        assert response.status_code == 200
+
+    def test_admin_analytics_renders(self, client, superuser, listing):
+        BidFactory(listing=listing, amount=Decimal("15.00"))
+        client.force_login(superuser)
+        response = client.get(reverse("admin_analytics"))
+        assert response.status_code == 200
+
+    def test_admin_reports_renders(self, client, superuser, listing):
+        client.force_login(superuser)
+        response = client.get(reverse("admin_reports"))
+        assert response.status_code == 200
+
+
+@pytest.mark.django_db
+class TestAdminListings:
+    def test_admin_listings_renders(self, client, superuser, listing):
+        client.force_login(superuser)
+        response = client.get(reverse("admin_listings"))
+        assert response.status_code == 200
+        assert listing.title.encode() in response.content
+
+    def test_admin_listings_search_filter(self, client, superuser, listing):
+        client.force_login(superuser)
+        response = client.get(reverse("admin_listings"), {"search": listing.title})
+        assert response.status_code == 200
+        assert listing.title.encode() in response.content
+
+    def test_admin_listings_category_and_status_filters(self, client, superuser):
+        ListingFactory(category="Books", active=True)
+        ListingFactory(category="Toys", active=False)
+        client.force_login(superuser)
+
+        response = client.get(
+            reverse("admin_listings"), {"category": "Books", "status": "active"}
+        )
+        assert response.status_code == 200
+
+        response = client.get(reverse("admin_listings"), {"status": "inactive"})
+        assert response.status_code == 200
+
+        response = client.get(reverse("admin_listings"), {"status": "with_bids"})
+        assert response.status_code == 200
+
+    def test_admin_listing_detail_renders(self, client, superuser, listing):
+        BidFactory(listing=listing)
+        client.force_login(superuser)
+        response = client.get(reverse("admin_listing_detail", args=[listing.id]))
+        assert response.status_code == 200
+
+    def test_admin_toggle_listing_status(self, client, superuser, listing):
+        client.force_login(superuser)
+        was_active = listing.active
+        response = client.post(
+            reverse("admin_toggle_listing_status", args=[listing.id])
+        )
+        assert response.status_code == 302
+        listing.refresh_from_db()
+        assert listing.active is not was_active
+
+
+@pytest.mark.django_db
+class TestAdminUsers:
+    def test_admin_users_renders(self, client, superuser, user):
+        client.force_login(superuser)
+        response = client.get(reverse("admin_users"))
+        assert response.status_code == 200
+        assert user.username.encode() in response.content
+
+    def test_admin_users_search_filter(self, client, superuser, user):
+        client.force_login(superuser)
+        response = client.get(reverse("admin_users"), {"search": user.username})
+        assert response.status_code == 200
+
+
+@pytest.mark.django_db
+class TestAdminApiEndpoints:
+    def test_admin_api_metrics(self, client, superuser, listing):
+        client.force_login(superuser)
+        response = client.get(reverse("admin_api_metrics"))
+        assert response.status_code == 200
+        assert response.json()["total_listings"] >= 1
+
+    @pytest.mark.parametrize("chart_type", ["trends", "categories", "bids", "unknown"])
+    def test_admin_api_charts(self, client, superuser, listing, chart_type):
+        client.force_login(superuser)
+        response = client.get(reverse("admin_api_charts"), {"type": chart_type})
+        assert response.status_code == 200
+
+
+@pytest.mark.django_db
+class TestAdminExportData:
+    @pytest.mark.parametrize("export_type", ["listings", "bids", "users"])
+    def test_admin_export_data(self, client, superuser, listing, export_type):
+        BidFactory(listing=listing)
+        client.force_login(superuser)
+        response = client.get(reverse("admin_export_data"), {"type": export_type})
+        assert response.status_code == 200
+        assert response["Content-Type"] == "text/csv"
+
+
+@pytest.mark.django_db
+def test_test_admin_dashboard_view_renders(client):
+    response = client.get(reverse("test_admin"))
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_catch_all_404_view(client):
+    response = client.get("/this-route-does-not-exist")
+    assert response.status_code == 404

--- a/tests/unit/test_analytics.py
+++ b/tests/unit/test_analytics.py
@@ -1,0 +1,90 @@
+from datetime import timedelta
+from decimal import Decimal
+
+import pytest
+from django.utils import timezone
+
+from auctions.analytics import AuctionAnalytics
+from auctions.models import Listing
+from tests.conftest import BidFactory, ListingFactory, UserFactory
+
+
+@pytest.mark.django_db
+class TestGetTimeSeriesData:
+    """These queries used to run SQLite-only .extra() SQL (CODE-001);
+    they must produce the same grouped output on PostgreSQL."""
+
+    def test_groups_listings_by_day(self):
+        today = timezone.now()
+        listing1 = ListingFactory()
+        listing2 = ListingFactory()
+        Listing.objects.filter(pk__in=[listing1.pk, listing2.pk]).update(created=today)
+
+        data = AuctionAnalytics().get_time_series_data(days=7)
+
+        today_str = today.date().isoformat()
+        matching = [item for item in data["listings"] if item["day"] == today_str]
+        assert len(matching) == 1
+        assert matching[0]["count"] == 2
+
+    def test_uses_correct_day_bucket_for_older_listing(self):
+        listing = ListingFactory()
+        target_date = timezone.now() - timedelta(days=2)
+        Listing.objects.filter(pk=listing.pk).update(created=target_date)
+
+        data = AuctionAnalytics().get_time_series_data(days=7)
+
+        target_str = target_date.date().isoformat()
+        matching = [item for item in data["listings"] if item["day"] == target_str]
+        assert len(matching) == 1
+        assert matching[0]["count"] == 1
+
+    def test_counts_bids_and_total_amount_by_listing_day(self):
+        listing = ListingFactory()
+        bidder = UserFactory()
+        BidFactory(listing=listing, user=bidder, amount=Decimal("15.00"))
+        BidFactory(listing=listing, user=bidder, amount=Decimal("25.00"))
+
+        data = AuctionAnalytics().get_time_series_data(days=7)
+
+        today_str = timezone.now().date().isoformat()
+        bids_today = next(item for item in data["bids"] if item["day"] == today_str)
+        assert bids_today["count"] == 2
+        assert bids_today["total_amount"] == Decimal("40.00")
+
+    def test_counts_users_joined_today(self):
+        UserFactory()
+
+        data = AuctionAnalytics().get_time_series_data(days=7)
+
+        today_str = timezone.now().date().isoformat()
+        users_today = next(item for item in data["users"] if item["day"] == today_str)
+        assert users_today["count"] >= 1
+
+
+@pytest.mark.django_db
+class TestGetMarketTrends:
+    """monthly_trends/seasonal_patterns used the SQLite-only strftime() SQL
+    (CODE-001); values must stay JSON/JS-safe strings after the fix."""
+
+    def test_monthly_trends_grouped_and_stringified(self):
+        ListingFactory(starting_bid=Decimal("10.00"), current_bid=Decimal("20.00"))
+
+        trends = AuctionAnalytics().get_market_trends()
+
+        assert trends["monthly_trends"]
+        entry = trends["monthly_trends"][0]
+        assert isinstance(entry["month"], str)
+        assert entry["month"] == timezone.now().strftime("%Y-%m")
+        assert entry["listings_count"] >= 1
+
+    def test_seasonal_patterns_grouped_and_zero_padded(self):
+        ListingFactory()
+
+        trends = AuctionAnalytics().get_market_trends()
+
+        assert trends["seasonal_patterns"]
+        entry = trends["seasonal_patterns"][0]
+        assert isinstance(entry["month"], str)
+        assert len(entry["month"]) == 2
+        assert entry["month"] == timezone.now().strftime("%m")

--- a/tests/unit/test_data_utils.py
+++ b/tests/unit/test_data_utils.py
@@ -1,0 +1,128 @@
+from decimal import Decimal
+
+import pytest
+
+from auctions.data_utils import AlertSystem, DataProcessor, ReportGenerator
+from tests.conftest import BidFactory, ListingFactory, UserFactory
+
+
+class TestDataProcessor:
+    def test_calculate_growth_rate(self):
+        assert DataProcessor.calculate_growth_rate(150, 100) == 50
+        assert DataProcessor.calculate_growth_rate(50, 100) == -50
+
+    def test_calculate_growth_rate_zero_previous(self):
+        assert DataProcessor.calculate_growth_rate(100, 0) == 0
+
+    def test_get_time_periods(self):
+        periods = DataProcessor.get_time_periods(days=10)
+        assert periods["days"] == 10
+        assert periods["end"] > periods["start"]
+
+    @pytest.mark.django_db
+    def test_calculate_engagement_score(self):
+        user = UserFactory()
+        listing = ListingFactory(user=user)
+        BidFactory(user=user, listing=listing)
+        score = DataProcessor.calculate_engagement_score(user)
+        # 1 listing (weight 3) + 1 bid (weight 2)
+        assert score == 5
+
+    def test_detect_anomalies_too_few_points(self):
+        assert DataProcessor.detect_anomalies([1, 2]) == []
+
+    def test_detect_anomalies_finds_outlier(self):
+        data = [10, 11, 9, 10, 100]
+        anomalies = DataProcessor.detect_anomalies(data, threshold=1)
+        assert any(a["value"] == 100 for a in anomalies)
+
+    def test_calculate_market_volatility_empty(self):
+        assert DataProcessor.calculate_market_volatility([]) == 0
+
+    def test_calculate_market_volatility_single_price(self):
+        assert DataProcessor.calculate_market_volatility([{"current_bid": 10}]) == 0
+
+    def test_calculate_market_volatility_computes_value(self):
+        listings_data = [
+            {"current_bid": 100, "starting_bid": 100},
+            {"current_bid": 110, "starting_bid": 100},
+            {"current_bid": 90, "starting_bid": 100},
+        ]
+        volatility = DataProcessor.calculate_market_volatility(listings_data)
+        assert volatility > 0
+
+
+@pytest.mark.django_db
+class TestReportGenerator:
+    def test_generate_user_activity_report_all_users(self):
+        user = UserFactory()
+        listing = ListingFactory(user=user)
+        BidFactory(user=user, listing=listing)
+
+        report = ReportGenerator.generate_user_activity_report(days=30)
+
+        entry = next(item for item in report if item["username"] == user.username)
+        assert entry["listings_created"] == 1
+        assert entry["bids_made"] == 1
+
+    def test_generate_user_activity_report_single_user(self):
+        user = UserFactory()
+        report = ReportGenerator.generate_user_activity_report(user_id=user.id, days=30)
+        assert len(report) == 1
+        assert report[0]["user_id"] == user.id
+
+    def test_generate_market_analysis_with_listings(self):
+        listing = ListingFactory(
+            starting_bid=Decimal("10.00"), current_bid=Decimal("20.00")
+        )
+        BidFactory(listing=listing)
+
+        analysis = ReportGenerator.generate_market_analysis(days=30)
+
+        assert analysis["total_listings"] >= 1
+        assert analysis["avg_starting_price"] >= 0
+        assert "category_breakdown" in analysis
+
+    def test_generate_market_analysis_no_listings(self):
+        analysis = ReportGenerator.generate_market_analysis(days=30)
+        assert analysis["avg_starting_price"] == 0
+        assert analysis["price_increase_percent"] == 0
+
+    def test_generate_performance_metrics(self):
+        user = UserFactory()
+        listing = ListingFactory(user=user)
+        BidFactory(user=user, listing=listing)
+
+        metrics = ReportGenerator.generate_performance_metrics(days=30)
+
+        assert metrics["total_listings"] >= 1
+        assert 0 <= metrics["conversion_rate"] <= 100
+
+
+@pytest.mark.django_db
+class TestAlertSystem:
+    def test_check_low_activity_alert_triggers_when_quiet(self):
+        alert = AlertSystem.check_low_activity_alert()
+        assert alert is not None
+        assert alert["type"] == "warning"
+
+    def test_check_low_activity_alert_none_when_active(self):
+        for _ in range(6):
+            listing = ListingFactory()
+            for _ in range(2):
+                BidFactory(listing=listing)
+        assert AlertSystem.check_low_activity_alert() is None
+
+    def test_check_high_value_alert_none_by_default(self):
+        assert AlertSystem.check_high_value_alert() is None
+
+    def test_check_high_value_alert_triggers(self):
+        BidFactory(amount=Decimal("15000.00"))
+        alert = AlertSystem.check_high_value_alert()
+        assert alert is not None
+        assert alert["type"] == "info"
+
+    def test_get_all_alerts_aggregates(self):
+        BidFactory(amount=Decimal("15000.00"))
+        alerts = AlertSystem.get_all_alerts()
+        assert any(a["type"] == "info" for a in alerts)


### PR DESCRIPTION
## Summary

Resolves `docs/tasks/p1-fix-analytics-postgres.md` ([audit detail](docs/audits/code-quality.md)):

- **CODE-001** — `analytics.py` imported `django.contrib.auth.models.User` (wrong model — the project uses a custom `AUTH_USER_MODEL`) and used `.extra()` with raw SQLite `date()`/`strftime()` SQL, which fails outright on PostgreSQL. Replaced with `get_user_model()` and `TruncDate`/`TruncMonth`/`ExtractMonth`, which are portable across both backends. The day/month grouping keys are stringified after the query so `analytics.html`'s existing `|safe`-embedded JS keeps working unchanged (that template's `|safe` usage is itself a separate, already-tracked finding: SEC-009, scoped to `fix/xss-templates`).
- **CODE-002** — `numpy`/`pandas`/`plotly`/`scikit-learn` were only in `requirements-dev.txt`, but the admin BI dashboard that imports them is a real production feature per `CLAUDE.md`'s architecture (not a future phase) — moved them to `requirements.txt`.

Also, while adding test coverage for the admin dashboard:

- Narrowed the broad `except Exception` in `admin_dashboard` to at least log the failure (`logger.exception(...)`) instead of silently swallowing it, per the ficha's instructions.
- Found and fixed a real, unrelated bug: `admin/listings.html` and `admin/listing_detail.html` use the custom `sub` template filter without `{% load auctions_filters %}`, so `/admin/listings` and `/admin/listing/<id>` raised `TemplateSyntaxError` on every single request. Fixed by adding the missing `{% load %}`.

## Test plan

- [x] Removed `auctions/admin_views.py`, `auctions/analytics.py`, `auctions/data_utils.py` from the coverage `omit` list (TEST-002)
- [x] Added `tests/unit/test_analytics.py` — `get_time_series_data`/`get_market_trends` with backdated records, verifying day/month bucketing and that output stays string-typed (this test would have caught CODE-001)
- [x] Added `tests/unit/test_data_utils.py` and `tests/integration/test_admin_views.py` covering the 13 admin views (dashboard, analytics, listings + filters, users + filters, listing detail, toggle status, reports, API metrics/charts, CSV export)
- [x] `pytest tests/unit/ tests/integration/` — 138 passed (SQLite locally)
- [x] Re-ran full suite against a real PostgreSQL 16 container (matching CI) — 138 passed, identical coverage
- [x] Coverage 86.04% (up from 82% while these files were omitted; min 70%)
- [x] `ruff check .` / `black --check .` — clean
- [x] `bandit -r auctions/ -ll` — no issues (13 pre-existing Low findings in legacy test suite, unchanged)
- [x] `mypy auctions/` — only the pre-existing unrelated error (CODE-010, out of scope)
- [x] Manually verified `/admin/listings`, `/admin/listing/<id>`, `/admin/dashboard`, `/admin/analytics` render 200 and the `sub` filter computes the correct price delta